### PR TITLE
fix(shadow coordinate. item material)

### DIFF
--- a/Assets/HIS/Prefabs/Item_Consume.prefab
+++ b/Assets/HIS/Prefabs/Item_Consume.prefab
@@ -56,7 +56,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/HIS/Prefabs/Item_Equipment.prefab
+++ b/Assets/HIS/Prefabs/Item_Equipment.prefab
@@ -56,7 +56,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/LightSystem/Prefabs/LightSystem_3F_Integrated.prefab
+++ b/Assets/LightSystem/Prefabs/LightSystem_3F_Integrated.prefab
@@ -59,7 +59,7 @@ MonoBehaviour:
   - {x: 5.4184933, y: -0.5283375, z: 0}
   m_ShapePathHash: 1332983799
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75518
+  m_InstanceId: -20332
   m_LocalBounds:
     m_Center: {x: 2.4599211, y: -0.3041687, z: 0}
     m_Extent: {x: 2.9899213, y: 0.22416878, z: 0}
@@ -122,7 +122,7 @@ MonoBehaviour:
   - {x: 5.4184933, y: -0.5283375, z: 0}
   m_ShapePathHash: 1332983799
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75524
+  m_InstanceId: -20338
   m_LocalBounds:
     m_Center: {x: 2.4599211, y: -0.3041687, z: 0}
     m_Extent: {x: 2.9899213, y: 0.22416878, z: 0}
@@ -185,7 +185,7 @@ MonoBehaviour:
   - {x: 6.4758015, y: -0.516603, z: 0}
   m_ShapePathHash: 786653564
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75548
+  m_InstanceId: -20362
   m_LocalBounds:
     m_Center: {x: 2.9729006, y: -0.29830146, z: 0}
     m_Extent: {x: 3.5029008, y: 0.21830153, z: 0}
@@ -214,7 +214,7 @@ Transform:
   m_GameObject: {fileID: 1874303373709852409}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.5, y: -0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -327,7 +327,7 @@ MonoBehaviour:
   - {x: 0.5, y: -7.7463665, z: 0}
   m_ShapePathHash: -2060620555
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75596
+  m_InstanceId: -20410
   m_LocalBounds:
     m_Center: {x: 0, y: -2.0481834, z: 0}
     m_Extent: {x: 0.5, y: 5.698183, z: 0}
@@ -390,7 +390,7 @@ MonoBehaviour:
   - {x: 14.397717, y: -0.5313206, z: 0}
   m_ShapePathHash: 1677533792
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75554
+  m_InstanceId: -20368
   m_LocalBounds:
     m_Center: {x: 6.937947, y: -0.30566025, z: 0}
     m_Extent: {x: 7.467947, y: 0.22566032, z: 0}
@@ -453,7 +453,7 @@ MonoBehaviour:
   - {x: 5.4184933, y: -0.5283375, z: 0}
   m_ShapePathHash: 1332983799
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75530
+  m_InstanceId: -20344
   m_LocalBounds:
     m_Center: {x: 2.4599211, y: -0.3041687, z: 0}
     m_Extent: {x: 2.9899213, y: 0.22416878, z: 0}
@@ -515,7 +515,7 @@ MonoBehaviour:
   - {x: 0.5, y: -7.7463665, z: 0}
   m_ShapePathHash: -2060620555
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75584
+  m_InstanceId: -20398
   m_LocalBounds:
     m_Center: {x: 0, y: -2.0481834, z: 0}
     m_Extent: {x: 0.5, y: 5.698183, z: 0}
@@ -755,7 +755,7 @@ MonoBehaviour:
   - {x: 0.5, y: -7.64, z: 0}
   m_ShapePathHash: -593049747
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75572
+  m_InstanceId: -20386
   m_LocalBounds:
     m_Center: {x: 0, y: -3.6399999, z: 0}
     m_Extent: {x: 0.5, y: 4, z: 0}
@@ -817,7 +817,7 @@ MonoBehaviour:
   - {x: 0.5, y: -7.64, z: 0}
   m_ShapePathHash: -593049747
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75566
+  m_InstanceId: -20380
   m_LocalBounds:
     m_Center: {x: 0, y: -3.6399999, z: 0}
     m_Extent: {x: 0.5, y: 4, z: 0}
@@ -879,7 +879,7 @@ MonoBehaviour:
   - {x: 0.48919296, y: -3.8145485, z: 0}
   m_ShapePathHash: 470808117
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75590
+  m_InstanceId: -20404
   m_LocalBounds:
     m_Center: {x: 0, y: -0.08227444, z: 0}
     m_Extent: {x: 0.5, y: 3.732274, z: 0}
@@ -941,7 +941,7 @@ MonoBehaviour:
   - {x: 9.330046, y: -4.5798836, z: 0}
   m_ShapePathHash: 441493447
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75608
+  m_InstanceId: -20422
   m_LocalBounds:
     m_Center: {x: 4.34, y: -2.3649416, z: 0}
     m_Extent: {x: 5, y: 2.214942, z: 0}
@@ -1085,7 +1085,7 @@ MonoBehaviour:
   - {x: 0.5, y: -7.7463665, z: 0}
   m_ShapePathHash: -2060620555
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75602
+  m_InstanceId: -20416
   m_LocalBounds:
     m_Center: {x: 0, y: -2.0481834, z: 0}
     m_Extent: {x: 0.5, y: 5.698183, z: 0}
@@ -1138,7 +1138,7 @@ MonoBehaviour:
   m_BlendStyleIndex: 0
   m_FalloffIntensity: 0.5
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Intensity: 0
+  m_Intensity: 0.005
   m_LightVolumeIntensity: 1
   m_LightVolumeIntensityEnabled: 0
   m_ApplyToSortingLayers: 00000000
@@ -1312,7 +1312,7 @@ MonoBehaviour:
   - {x: 6.470503, y: -0.48937416, z: 0}
   m_ShapePathHash: 1709133127
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75536
+  m_InstanceId: -20350
   m_LocalBounds:
     m_Center: {x: 2.9702513, y: -0.28468752, z: 0}
     m_Extent: {x: 3.5002515, y: 0.21531248, z: 0}
@@ -1374,7 +1374,7 @@ MonoBehaviour:
   - {x: 0.55999994, y: -7.65, z: 0}
   m_ShapePathHash: -773426691
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75578
+  m_InstanceId: -20392
   m_LocalBounds:
     m_Center: {x: 0.059999943, y: -2.15, z: 0}
     m_Extent: {x: 0.5, y: 5.5, z: 0}
@@ -1436,7 +1436,7 @@ MonoBehaviour:
   - {x: 5.5167747, y: -0.49247932, z: 0}
   m_ShapePathHash: 1277641317
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75560
+  m_InstanceId: -20374
   m_LocalBounds:
     m_Center: {x: 2.5153997, y: -0.29851627, z: 0}
     m_Extent: {x: 3.002625, y: 0.20148373, z: 0}
@@ -1796,7 +1796,7 @@ MonoBehaviour:
   - {x: 3.472566, y: -0.46714306, z: 0}
   m_ShapePathHash: 837487325
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75542
+  m_InstanceId: -20356
   m_LocalBounds:
     m_Center: {x: 1.4844809, y: -0.25, z: 0}
     m_Extent: {x: 1.9955251, y: 0.25, z: 0}
@@ -1859,7 +1859,7 @@ MonoBehaviour:
   - {x: 6.466984, y: -0.5, z: 0}
   m_ShapePathHash: -689580096
   m_Mesh: {fileID: 0}
-  m_InstanceId: -75512
+  m_InstanceId: -20326
   m_LocalBounds:
     m_Center: {x: 2.9699998, y: -0.28999996, z: 0}
     m_Extent: {x: 3.5, y: 0.21000004, z: 0}


### PR DESCRIPTION
맵 실제 위치와 그림자 캐스터의 위치가 달라서 그림자 캐스터의 위치를 x,y방향으로 -0.5만큼 위치를 옮김
아이템이 조명에 영향을 받지 않는 문제를 발견해서 아이템들의 머티리얼을 default에서 Lit-Default로 변경해서 조명에 영향을 받게끔 변경함.