### PR TITLE
92 fix avoider stunnee onspotlight event

### DIFF
--- a/Assets/CreatureAI/Scenes/3F_Merge_08.19.unity
+++ b/Assets/CreatureAI/Scenes/3F_Merge_08.19.unity
@@ -287,11 +287,336 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1 &49028054 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8827318982427012109, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
-  m_PrefabInstance: {fileID: 1988093605}
+--- !u!43 &27053665
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: 2.4599211, y: -0.3041687, z: 0}
+      m_Extent: {x: 2.9899213, y: 0.22416878, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020000000300010004000300000005000300040006000300050003000600070002000800000000000900040001000a00020003000b00010007000c00030004000d00050005000e00060006000f000700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: 4c64ad40204107bf00000000334a7f3fdb7098bd00000080000000804c64ad40204107bf4c64ad40204107bf1c65ae4080e0ddbd000000001b499b3b43ff7f3f00000080000000801c65ae4080e0ddbd1c65ae4080e0ddbdb4e4ad4030fda2be00000000334a7f3fdb7098bd00000080000000801c65ae4080e0ddbd4c64ad40204107bf596f1d40c0dbc0bd000000001b499b3b43ff7f3f000000800000008018ae07bf00d7a3bd1c65ae4080e0ddbdb65d1d4090a003bf000000005dde9cbb40ff7fbf00000000000000804c64ad40204107bfb03400bf000000bfb03400bf000000bf000000005dde9cbb40ff7fbf0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd18ae07bf00d7a3bd0000000039627fbf16068ebd000000000000008018ae07bf00d7a3bd18ae07bf00d7a3bdb4e4ad4030fda2be00000000334a7f3fdb7098bd00000080000000801c65ae4080e0ddbd4c64ad40204107bf4c64ad40204107bf000000005dde9cbb40ff7fbf00000000000000804c64ad40204107bf4c64ad40204107bf1c65ae4080e0ddbd00000000334a7f3fdb7098bd00000080000000801c65ae4080e0ddbd1c65ae4080e0ddbd596f1d40c0dbc0bd000000001b499b3b43ff7f3f000000800000008018ae07bf00d7a3bd1c65ae4080e0ddbd18ae07bf00d7a3bd000000001b499b3b43ff7f3f000000800000008018ae07bf00d7a3bd18ae07bf00d7a3bdb65d1d4090a003bf000000005dde9cbb40ff7fbf00000000000000804c64ad40204107bfb03400bf000000bfb03400bf000000bf0000000039627fbf16068ebd0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 2.4599211, y: -0.3041687, z: 0}
+    m_Extent: {x: 2.9899213, y: 0.22416878, z: 0}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &44302469
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: 2.9729006, y: -0.29830146, z: 0}
+      m_Extent: {x: 3.5029008, y: 0.21830153, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020000000300010000000400030005000400000006000400050004000600070002000800000000000900050001000a00020003000b00010004000c00030007000d00040005000e00060006000f000700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: c4393f400c2002bf0000000012fb1bbbd1ff7fbf0000000000000080c439cf40184004bf000000bf000000bf0022cf40f8ba98be0000000037fa7f3f56ad593c00000080000000803d0acf4000d7a3bdc439cf40184004bfc439cf40184004bf0000000036fa7f3f7eb6593c0000008000000080c439cf40184004bfc439cf40184004bf3d0acf4000d7a3bd00000000000000800000803f00000080000000803d0acf4000d7a3bd3d0acf4000d7a3bd7a143e4000d7a3bd00000000000000800000803f000000800000008018ae07bf00d7a3bd3d0acf4000d7a3bd000000bf000000bf0000000012fb1bbbd1ff7fbf0000000000000080000000bf000000bf000000bf000000bf0cd703bfe07a94be0000000073597fbf3aea91bd0000000000000080000000bf000000bf18ae07bf00d7a3bd18ae07bf00d7a3bd0000000073597fbf3aea91bd000000000000008018ae07bf00d7a3bd18ae07bf00d7a3bdc439cf40184004bf0000000012fb1bbbd1ff7fbf0000000000000080c439cf40184004bfc439cf40184004bfc4393f400c2002bf0000000012fb1bbbd1ff7fbf0000000000000080c439cf40184004bf000000bf000000bf0022cf40f8ba98be0000000036fa7f3f7eb6593c00000080000000803d0acf4000d7a3bdc439cf40184004bf3d0acf4000d7a3bd0000000037fa7f3f56ad593c00000080000000803d0acf4000d7a3bd3d0acf4000d7a3bd7a143e4000d7a3bd00000000000000800000803f000000800000008018ae07bf00d7a3bd3d0acf4000d7a3bd18ae07bf00d7a3bd00000000000000800000803f000000800000008018ae07bf00d7a3bd18ae07bf00d7a3bd000000bf000000bf0000000073597fbf3aea91bd0000000000000080000000bf000000bf000000bf000000bf0cd703bfe07a94be0000000073597fbf3aea91bd0000000000000080000000bf000000bf18ae07bf00d7a3bd
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 2.9729006, y: -0.29830146, z: 0}
+    m_Extent: {x: 3.5029008, y: 0.21830153, z: 0}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1001 &87606067
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1053,67 +1378,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 574ab1e38ff6e9541ba923c92c96743e, type: 3}
---- !u!1001 &103886628
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -23.4348
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 5.877049
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5716833242501837917, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_Name
-      value: Monster (2)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5716833242501837917, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
 --- !u!114 &112134600 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 770022267135074472, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
@@ -1259,55 +1523,7 @@ RectTransform:
   m_AnchoredPosition: {x: 0.0001, y: 0}
   m_SizeDelta: {x: 534.218, y: 119.4764}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &157149569
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 157149571}
-  - component: {fileID: 157149570}
-  m_Layer: 0
-  m_Name: Dialogue_Controller
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &157149570
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 157149569}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8c18bfa2036896340b46c3c79813180e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  GetOutFirstRoom: 0
-  GetInRightDownRoom: 0
-  GetInRightUpRoom: 0
-  CheckStairRoom: 0
---- !u!4 &157149571
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 157149569}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -14.792669, y: 9.574853, z: 0.6793224}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &189739020
+--- !u!43 &154359262
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1324,8 +1540,8 @@ Mesh:
     firstVertex: 0
     vertexCount: 16
     localAABB:
-      m_Center: {x: 2.9702513, y: -0.28468752, z: 0}
-      m_Extent: {x: 3.5002515, y: 0.21531248, z: 0}
+      m_Center: {x: 2.9699998, y: -0.28999996, z: 0}
+      m_Extent: {x: 3.5, y: 0.21000004, z: 0}
   m_Shapes:
     vertices: []
     shapes: []
@@ -1342,7 +1558,7 @@ Mesh:
   m_KeepVertices: 1
   m_KeepIndices: 1
   m_IndexFormat: 0
-  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
+  m_IndexBuffer: 00000100020000000300010000000400030005000400000006000400050004000600070002000800000000000900050001000a00020003000b00010004000c00030007000d00040005000e00060006000f000700
   m_VertexData:
     serializedVersion: 3
     m_VertexCount: 16
@@ -1404,7 +1620,7 @@ Mesh:
       format: 0
       dimension: 0
     m_DataSize: 704
-    _typelessdata: 5c0ecf40408ffabe000000003bf57f3fe17c943c00000080000000805c0ecf40408ffabe5c0ecf40408ffabefccfce4080148ebd000000000526c7baedff7f3f0000008000000080fccfce4080148ebdfccfce4080148ebd2cefce40300a8fbe000000003bf57f3fe17c943c0000008000000080fccfce4080148ebd5c0ecf40408ffabec6073f40a047fdbe0000000071c8c73aecff7fbf00000080000000805c0ecf40408ffabeb03400bf000000bf39da3d40c0f598bd000000000526c7baedff7f3f000000800000008018ae07bf00d7a3bdfccfce4080148ebdb03400bf000000bf0000000071c8c73aecff7fbf0000008000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd18ae07bf00d7a3bd0000000039627fbf16068ebd000000000000008018ae07bf00d7a3bd18ae07bf00d7a3bd2cefce40300a8fbe000000003bf57f3fe17c943c0000008000000080fccfce4080148ebd5c0ecf40408ffabe5c0ecf40408ffabe0000000071c8c73aecff7fbf00000080000000805c0ecf40408ffabe5c0ecf40408ffabefccfce4080148ebd000000003bf57f3fe17c943c0000008000000080fccfce4080148ebdfccfce4080148ebd39da3d40c0f598bd000000000526c7baedff7f3f000000800000008018ae07bf00d7a3bdfccfce4080148ebdc6073f40a047fdbe0000000071c8c73aecff7fbf00000080000000805c0ecf40408ffabeb03400bf000000bf18ae07bf00d7a3bd000000000526c7baedff7f3f000000800000008018ae07bf00d7a3bd18ae07bf00d7a3bdb03400bf000000bf0000000039627fbf16068ebd0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd
+    _typelessdata: f2ea3e40000000bf0000000000000080000080bf000000000000008088f1ce40000000bfb03400bf000000bfe2fdce40e07a94be0000000050fe7f3f0e56ebbb00000080000000803d0acf4000d7a3bd88f1ce40000000bf88f1ce40000000bf0000000050fe7f3f0243ebbb000000800000008088f1ce40000000bf88f1ce40000000bf3d0acf4000d7a3bd00000000000000800000803f00000080000000803d0acf4000d7a3bd3d0acf4000d7a3bd7a143e4000d7a3bd00000000000000800000803f000000800000008018ae07bf00d7a3bd3d0acf4000d7a3bdb03400bf000000bf0000000000000080000080bf0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd18ae07bf00d7a3bd0000000039627fbf16068ebd000000000000008018ae07bf00d7a3bd18ae07bf00d7a3bd88f1ce40000000bf0000000000000080000080bf000000000000008088f1ce40000000bf88f1ce40000000bff2ea3e40000000bf0000000000000080000080bf000000000000008088f1ce40000000bfb03400bf000000bfe2fdce40e07a94be0000000050fe7f3f0243ebbb00000080000000803d0acf4000d7a3bd88f1ce40000000bf3d0acf4000d7a3bd0000000050fe7f3f0e56ebbb00000080000000803d0acf4000d7a3bd3d0acf4000d7a3bd7a143e4000d7a3bd00000000000000800000803f000000800000008018ae07bf00d7a3bd3d0acf4000d7a3bd18ae07bf00d7a3bd00000000000000800000803f000000800000008018ae07bf00d7a3bd18ae07bf00d7a3bdb03400bf000000bf0000000039627fbf16068ebd0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd
   m_CompressedMesh:
     m_Vertices:
       m_NumItems: 0
@@ -1458,8 +1674,8 @@ Mesh:
       m_BitSize: 0
     m_UVInfo: 0
   m_LocalAABB:
-    m_Center: {x: 2.9702513, y: -0.28468752, z: 0}
-    m_Extent: {x: 3.5002515, y: 0.21531248, z: 0}
+    m_Center: {x: 2.9699998, y: -0.28999996, z: 0}
+    m_Extent: {x: 3.5, y: 0.21000004, z: 0}
   m_MeshUsageFlags: 0
   m_CookingOptions: 30
   m_BakedConvexCollisionMesh: 
@@ -1472,6 +1688,54 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!1 &157149569
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 157149571}
+  - component: {fileID: 157149570}
+  m_Layer: 0
+  m_Name: Dialogue_Controller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &157149570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 157149569}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c18bfa2036896340b46c3c79813180e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  GetOutFirstRoom: 0
+  GetInRightDownRoom: 0
+  GetInRightUpRoom: 0
+  CheckStairRoom: 0
+--- !u!4 &157149571
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 157149569}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -14.792669, y: 9.574853, z: 0.6793224}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!43 &193091512
 Mesh:
   m_ObjectHideFlags: 0
@@ -1637,6 +1901,171 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!43 &245805439
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: 0.059999943, y: -2.15, z: 0}
+      m_Extent: {x: 0.5, y: 5.5, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: 285c0f3fcdccf4c0000000000000803f000000800000008000000080285c0f3fcdccf4c0285c0f3fcdccf4c0285c0f3f6666564000000000000000800000803f0000008000000080285c0f3f66665640285c0f3f66665640285c0f3f9a9909c0000000000000803f000000800000008000000080285c0f3f66665640285c0f3fcdccf4c080c2753dcdccf4c00000000000000080000080bf0000000000000080285c0f3fcdccf4c0b047e1becdccf4c080c2753d6666564000000000000000800000803f0000008000000080b047e1be66665640285c0f3f66665640b047e1becdccf4c00000000000000080000080bf0000000000000080b047e1becdccf4c0b047e1becdccf4c0b047e1be9a9909c000000000000080bf000000800000008000000080b047e1becdccf4c0b047e1be66665640b047e1be6666564000000000000080bf000000800000008000000080b047e1be66665640b047e1be66665640285c0f3f9a9909c0000000000000803f000000800000008000000080285c0f3f66665640285c0f3fcdccf4c0285c0f3fcdccf4c00000000000000080000080bf0000000000000080285c0f3fcdccf4c0285c0f3fcdccf4c0285c0f3f66665640000000000000803f000000800000008000000080285c0f3f66665640285c0f3f6666564080c2753d6666564000000000000000800000803f0000008000000080b047e1be66665640285c0f3f6666564080c2753dcdccf4c00000000000000080000080bf0000000000000080285c0f3fcdccf4c0b047e1becdccf4c0b047e1be6666564000000000000000800000803f0000008000000080b047e1be66665640b047e1be66665640b047e1becdccf4c000000000000080bf000000800000008000000080b047e1becdccf4c0b047e1becdccf4c0b047e1be9a9909c000000000000080bf000000800000008000000080b047e1becdccf4c0b047e1be66665640
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0.059999943, y: -2.15, z: 0}
+    m_Extent: {x: 0.5, y: 5.5, z: 0}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!114 &274706475 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4349133205938479801, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
@@ -1648,67 +2077,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &297837743
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 13.496764
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 6.2682734
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5716833242501837917, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_Name
-      value: Monster (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5716833242501837917, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
 --- !u!43 &310941730
 Mesh:
   m_ObjectHideFlags: 0
@@ -1895,11 +2263,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 184661206369193150, guid: 12f68f18132644583b8733da542dff7d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 11.025192
+      value: 13.17
       objectReference: {fileID: 0}
     - target: {fileID: 184661206369193150, guid: 12f68f18132644583b8733da542dff7d, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 7.7291546
+      value: 10.34
       objectReference: {fileID: 0}
     - target: {fileID: 184661206369193150, guid: 12f68f18132644583b8733da542dff7d, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1953,7 +2321,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!43 &440649119
+--- !u!43 &394168746
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1970,8 +2338,8 @@ Mesh:
     firstVertex: 0
     vertexCount: 16
     localAABB:
-      m_Center: {x: 2.4599211, y: -0.3041687, z: 0}
-      m_Extent: {x: 2.9899213, y: 0.22416878, z: 0}
+      m_Center: {x: 6.9379463, y: -0.30566025, z: 0}
+      m_Extent: {x: 7.467947, y: 0.22566032, z: 0}
   m_Shapes:
     vertices: []
     shapes: []
@@ -1988,7 +2356,7 @@ Mesh:
   m_KeepVertices: 1
   m_KeepIndices: 1
   m_IndexFormat: 0
-  m_IndexBuffer: 00000100020000000300010004000300000005000300040006000300050003000600070002000800000000000900040001000a00020003000b00010007000c00030004000d00050005000e00060006000f000700
+  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
   m_VertexData:
     serializedVersion: 3
     m_VertexCount: 16
@@ -2050,7 +2418,7 @@ Mesh:
       format: 0
       dimension: 0
     m_DataSize: 704
-    _typelessdata: 4c64ad40204107bf00000000334a7f3fdb7098bd00000080000000804c64ad40204107bf4c64ad40204107bf1c65ae4080e0ddbd000000001b499b3b43ff7f3f00000080000000801c65ae4080e0ddbd1c65ae4080e0ddbdb4e4ad4030fda2be00000000334a7f3fdb7098bd00000080000000801c65ae4080e0ddbd4c64ad40204107bf596f1d40c0dbc0bd000000001b499b3b43ff7f3f000000800000008018ae07bf00d7a3bd1c65ae4080e0ddbdb65d1d4090a003bf000000005dde9cbb40ff7fbf00000000000000804c64ad40204107bfb03400bf000000bfb03400bf000000bf000000005dde9cbb40ff7fbf0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd18ae07bf00d7a3bd0000000039627fbf16068ebd000000000000008018ae07bf00d7a3bd18ae07bf00d7a3bdb4e4ad4030fda2be00000000334a7f3fdb7098bd00000080000000801c65ae4080e0ddbd4c64ad40204107bf4c64ad40204107bf000000005dde9cbb40ff7fbf00000000000000804c64ad40204107bf4c64ad40204107bf1c65ae4080e0ddbd00000000334a7f3fdb7098bd00000080000000801c65ae4080e0ddbd1c65ae4080e0ddbd596f1d40c0dbc0bd000000001b499b3b43ff7f3f000000800000008018ae07bf00d7a3bd1c65ae4080e0ddbd18ae07bf00d7a3bd000000001b499b3b43ff7f3f000000800000008018ae07bf00d7a3bd18ae07bf00d7a3bdb65d1d4090a003bf000000005dde9cbb40ff7fbf00000000000000804c64ad40204107bfb03400bf000000bfb03400bf000000bf0000000039627fbf16068ebd0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd
+    _typelessdata: 0d5d6641a00408bf00000000e7f37f3ff8609dbc00000080000000800d5d6641a00408bf0d5d6641a00408bf8a7e664100a0d8bd00000000d82ee23ae7ff7f3f00000080000000808a7e664100a0d8bd8a7e664100a0d8bdcc6d6641a018a3be00000000eaf37f3f93579dbc00000080000000808a7e664100a0d8bd0d5d6641a00408bf0d5dde40500204bf00000000e7c709bbdaff7fbf00000000000000800d5d6641a00408bf000000bf000000bfa803de40803bbebd00000000d92ee23ae7ff7f3f000000800000008018ae07bf00d7a3bd8a7e664100a0d8bd000000bf000000bf00000000e7c709bbdaff7fbf0000000000000080000000bf000000bf000000bf000000bf0cd703bfe07a94be0000000073597fbf3aea91bd0000000000000080000000bf000000bf18ae07bf00d7a3bd18ae07bf00d7a3bd0000000073597fbf3aea91bd000000000000008018ae07bf00d7a3bd18ae07bf00d7a3bdcc6d6641a018a3be00000000e7f37f3ff8609dbc00000080000000808a7e664100a0d8bd0d5d6641a00408bf0d5d6641a00408bf00000000e7c709bbdaff7fbf00000000000000800d5d6641a00408bf0d5d6641a00408bf8a7e664100a0d8bd00000000eaf37f3f93579dbc00000080000000808a7e664100a0d8bd8a7e664100a0d8bda803de40803bbebd00000000d82ee23ae7ff7f3f000000800000008018ae07bf00d7a3bd8a7e664100a0d8bd0d5dde40500204bf00000000e7c709bbdaff7fbf00000000000000800d5d6641a00408bf000000bf000000bf18ae07bf00d7a3bd00000000d92ee23ae7ff7f3f000000800000008018ae07bf00d7a3bd18ae07bf00d7a3bd000000bf000000bf0000000073597fbf3aea91bd0000000000000080000000bf000000bf000000bf000000bf0cd703bfe07a94be0000000073597fbf3aea91bd0000000000000080000000bf000000bf18ae07bf00d7a3bd
   m_CompressedMesh:
     m_Vertices:
       m_NumItems: 0
@@ -2104,8 +2472,8 @@ Mesh:
       m_BitSize: 0
     m_UVInfo: 0
   m_LocalAABB:
-    m_Center: {x: 2.4599211, y: -0.3041687, z: 0}
-    m_Extent: {x: 2.9899213, y: 0.22416878, z: 0}
+    m_Center: {x: 6.9379463, y: -0.30566025, z: 0}
+    m_Extent: {x: 7.467947, y: 0.22566032, z: 0}
   m_MeshUsageFlags: 0
   m_CookingOptions: 30
   m_BakedConvexCollisionMesh: 
@@ -2462,245 +2830,17 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 382615813667128817, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
   m_PrefabInstance: {fileID: 1988093605}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &481488473
+--- !u!114 &520023049 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 9201528321643486030, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
+  m_PrefabInstance: {fileID: 986739328}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 481488466}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 12498349756cf40e4a21ce7bf33dd686, type: 3}
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &481488474
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 481488466}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fc67f8b1ea08044d4ba016a9bb46456b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  debugMode: 1
-  viewAngle: 120
-  lookingAngle: 3
-  targetMask:
-    serializedVersion: 2
-    m_Bits: 0
---- !u!114 &481488475
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 481488466}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7e7b27be4f640de4c93a3a3e3d1e5c0a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  handlightObject: {fileID: 49028054}
---- !u!114 &481488476
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 481488466}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e047b33a0673c0f47b7dc4202816abed, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  handlightObject: {fileID: 49028054}
---- !u!114 &481488483
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 481488466}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bf89eb763392b67448840be5f0794184, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  mentalSlider: {fileID: 986739329}
-  staminaSlider: {fileID: 986739330}
-  curMental: 0
-  maxMental: 100
-  curStamina: 0
-  maxStamina: 100
---- !u!43 &589417771
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 11
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: 0, y: -2.0481834, z: 0}
-      m_Extent: {x: 0.5, y: 5.698183, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: 0000003f3ce2f7c0000000000000803f0000008000000080000000800000003f3ce2f7c00000003f3ce2f7c00000003f9899694000000000000000800000803f00000080000000800000003f989969400000003f989969400000003f701503c0000000000000803f0000008000000080000000800000003f989969400000003f3ce2f7c0000000003ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c0000000bf3ce2f7c0000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000bf3ce2f7c00000000000000080000080bf0000000000000080000000bf3ce2f7c0000000bf3ce2f7c0000000bf701503c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf98996940000000bf9899694000000000000080bf000000800000008000000080000000bf98996940000000bf989969400000003f701503c0000000000000803f0000008000000080000000800000003f989969400000003f3ce2f7c00000003f3ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c00000003f3ce2f7c00000003f98996940000000000000803f0000008000000080000000800000003f989969400000003f98996940000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000003ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c0000000bf3ce2f7c0000000bf9899694000000000000000800000803f0000008000000080000000bf98996940000000bf98996940000000bf3ce2f7c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf3ce2f7c0000000bf701503c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf98996940
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: -2.0481834, z: 0}
-    m_Extent: {x: 0.5, y: 5.698183, z: 0}
-  m_MeshUsageFlags: 0
-  m_CookingOptions: 30
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!114 &604344900 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7019309291860552708, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
@@ -2774,171 +2914,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &676316367
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 11
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: 0, y: -2.0481834, z: 0}
-      m_Extent: {x: 0.5, y: 5.698183, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: 0000003f3ce2f7c0000000000000803f0000008000000080000000800000003f3ce2f7c00000003f3ce2f7c00000003f9899694000000000000000800000803f00000080000000800000003f989969400000003f989969400000003f701503c0000000000000803f0000008000000080000000800000003f989969400000003f3ce2f7c0000000003ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c0000000bf3ce2f7c0000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000bf3ce2f7c00000000000000080000080bf0000000000000080000000bf3ce2f7c0000000bf3ce2f7c0000000bf701503c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf98996940000000bf9899694000000000000080bf000000800000008000000080000000bf98996940000000bf989969400000003f701503c0000000000000803f0000008000000080000000800000003f989969400000003f3ce2f7c00000003f3ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c00000003f3ce2f7c00000003f98996940000000000000803f0000008000000080000000800000003f989969400000003f98996940000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000003ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c0000000bf3ce2f7c0000000bf9899694000000000000000800000803f0000008000000080000000bf98996940000000bf98996940000000bf3ce2f7c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf3ce2f7c0000000bf701503c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf98996940
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: -2.0481834, z: 0}
-    m_Extent: {x: 0.5, y: 5.698183, z: 0}
-  m_MeshUsageFlags: 0
-  m_CookingOptions: 30
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!114 &717984408 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4842827895718304295, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
@@ -2950,7 +2925,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!43 &739782612
+--- !u!43 &720356171
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2967,8 +2942,8 @@ Mesh:
     firstVertex: 0
     vertexCount: 16
     localAABB:
-      m_Center: {x: 0, y: -2.0481834, z: 0}
-      m_Extent: {x: 0.5, y: 5.698183, z: 0}
+      m_Center: {x: 0, y: -3.6399999, z: 0}
+      m_Extent: {x: 0.5, y: 4, z: 0}
   m_Shapes:
     vertices: []
     shapes: []
@@ -3047,7 +3022,7 @@ Mesh:
       format: 0
       dimension: 0
     m_DataSize: 704
-    _typelessdata: 0000003f3ce2f7c0000000000000803f0000008000000080000000800000003f3ce2f7c00000003f3ce2f7c00000003f9899694000000000000000800000803f00000080000000800000003f989969400000003f989969400000003f701503c0000000000000803f0000008000000080000000800000003f989969400000003f3ce2f7c0000000003ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c0000000bf3ce2f7c0000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000bf3ce2f7c00000000000000080000080bf0000000000000080000000bf3ce2f7c0000000bf3ce2f7c0000000bf701503c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf98996940000000bf9899694000000000000080bf000000800000008000000080000000bf98996940000000bf989969400000003f701503c0000000000000803f0000008000000080000000800000003f989969400000003f3ce2f7c00000003f3ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c00000003f3ce2f7c00000003f98996940000000000000803f0000008000000080000000800000003f989969400000003f98996940000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000003ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c0000000bf3ce2f7c0000000bf9899694000000000000000800000803f0000008000000080000000bf98996940000000bf98996940000000bf3ce2f7c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf3ce2f7c0000000bf701503c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf98996940
+    _typelessdata: 0000003fe17af4c0000000000000803f0000008000000080000000800000003fe17af4c00000003fe17af4c00000003ff051b83e00000000000000800000803f00000080000000800000003ff051b83e0000003ff051b83e0000003fc2f568c0000000000000803f0000008000000080000000800000003ff051b83e0000003fe17af4c000000000e17af4c00000000000000080000080bf00000000000000800000003fe17af4c0000000bfe17af4c000000000f051b83e00000000000000800000803f0000008000000080000000bff051b83e0000003ff051b83e000000bfe17af4c00000000000000080000080bf0000000000000080000000bfe17af4c0000000bfe17af4c0000000bfc2f568c000000000000080bf000000800000008000000080000000bfe17af4c0000000bff051b83e000000bff051b83e00000000000080bf000000800000008000000080000000bff051b83e000000bff051b83e0000003fc2f568c0000000000000803f0000008000000080000000800000003ff051b83e0000003fe17af4c00000003fe17af4c00000000000000080000080bf00000000000000800000003fe17af4c00000003fe17af4c00000003ff051b83e000000000000803f0000008000000080000000800000003ff051b83e0000003ff051b83e00000000f051b83e00000000000000800000803f0000008000000080000000bff051b83e0000003ff051b83e00000000e17af4c00000000000000080000080bf00000000000000800000003fe17af4c0000000bfe17af4c0000000bff051b83e00000000000000800000803f0000008000000080000000bff051b83e000000bff051b83e000000bfe17af4c000000000000080bf000000800000008000000080000000bfe17af4c0000000bfe17af4c0000000bfc2f568c000000000000080bf000000800000008000000080000000bfe17af4c0000000bff051b83e
   m_CompressedMesh:
     m_Vertices:
       m_NumItems: 0
@@ -3101,8 +3076,8 @@ Mesh:
       m_BitSize: 0
     m_UVInfo: 0
   m_LocalAABB:
-    m_Center: {x: 0, y: -2.0481834, z: 0}
-    m_Extent: {x: 0.5, y: 5.698183, z: 0}
+    m_Center: {x: 0, y: -3.6399999, z: 0}
+    m_Extent: {x: 0.5, y: 4, z: 0}
   m_MeshUsageFlags: 0
   m_CookingOptions: 30
   m_BakedConvexCollisionMesh: 
@@ -3126,6 +3101,171 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!43 &753465345
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: 2.5154, y: -0.29851627, z: 0}
+      m_Extent: {x: 3.002625, y: 0.20148373, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020000000300010004000300000004000500030004000600050006000400070002000800000000000900040001000a00020003000b00010005000c00030004000d00070006000e00050007000f000600
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: 6b89b0404026fcbe00000000a5ff7f3fb5f856bb00000080000000806b89b0404026fcbe6b89b0404026fcbea993b04000ffe3bd000000003e6d1c3bd0ff7f3f0000008000000080a993b04000ffe3bda993b04000ffe3bd8a8eb04000939abe00000000a5ff7f3fb5f856bb0000008000000080a993b04000ffe3bd6b89b0404026fcbe45862140005cd5bd000000003d6d1c3bd0ff7f3f000000800000008044d6f0be00b9c6bda993b04000ffe3bd12f220402013febe000000009d2ea43af3ff7fbf00000080000000806b89b0404026fcbe9875f9be000000bf44d6f0be00b9c6bd00000000d8c67fbf3f072b3d000000800000008044d6f0be00b9c6bd44d6f0be00b9c6bdee25f5be20d798be00000000d8c67fbf3f072b3d00000080000000809875f9be000000bf44d6f0be00b9c6bd9875f9be000000bf000000009d2ea43af3ff7fbf00000080000000809875f9be000000bf9875f9be000000bf8a8eb04000939abe00000000a5ff7f3fb5f856bb0000008000000080a993b04000ffe3bd6b89b0404026fcbe6b89b0404026fcbe000000009d2ea43af3ff7fbf00000080000000806b89b0404026fcbe6b89b0404026fcbea993b04000ffe3bd00000000a5ff7f3fb5f856bb0000008000000080a993b04000ffe3bda993b04000ffe3bd45862140005cd5bd000000003e6d1c3bd0ff7f3f000000800000008044d6f0be00b9c6bda993b04000ffe3bd44d6f0be00b9c6bd000000003d6d1c3bd0ff7f3f000000800000008044d6f0be00b9c6bd44d6f0be00b9c6bd12f220402013febe000000009d2ea43af3ff7fbf00000080000000806b89b0404026fcbe9875f9be000000bfee25f5be20d798be00000000d8c67fbf3f072b3d00000080000000809875f9be000000bf44d6f0be00b9c6bd9875f9be000000bf00000000d8c67fbf3f072b3d00000080000000809875f9be000000bf9875f9be000000bf
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 2.5154, y: -0.29851627, z: 0}
+    m_Extent: {x: 3.002625, y: 0.20148373, z: 0}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!114 &761080115 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5237120249997278391, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
@@ -3212,6 +3352,171 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 764898188}
   m_CullTransparentMesh: 1
+--- !u!43 &787230655
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: 0, y: -2.0481834, z: 0}
+      m_Extent: {x: 0.5, y: 5.698183, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: 0000003f3ce2f7c0000000000000803f0000008000000080000000800000003f3ce2f7c00000003f3ce2f7c00000003f9899694000000000000000800000803f00000080000000800000003f989969400000003f989969400000003f701503c0000000000000803f0000008000000080000000800000003f989969400000003f3ce2f7c0000000003ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c0000000bf3ce2f7c0000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000bf3ce2f7c00000000000000080000080bf0000000000000080000000bf3ce2f7c0000000bf3ce2f7c0000000bf701503c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf98996940000000bf9899694000000000000080bf000000800000008000000080000000bf98996940000000bf989969400000003f701503c0000000000000803f0000008000000080000000800000003f989969400000003f3ce2f7c00000003f3ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c00000003f3ce2f7c00000003f98996940000000000000803f0000008000000080000000800000003f989969400000003f98996940000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000003ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c0000000bf3ce2f7c0000000bf9899694000000000000000800000803f0000008000000080000000bf98996940000000bf98996940000000bf3ce2f7c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf3ce2f7c0000000bf701503c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf98996940
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: -2.0481834, z: 0}
+    m_Extent: {x: 0.5, y: 5.698183, z: 0}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!43 &800157653
 Mesh:
   m_ObjectHideFlags: 0
@@ -3616,6 +3921,17 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!114 &850431952 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1296079252424844073, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
+  m_PrefabInstance: {fileID: 986739328}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!43 &879231877
 Mesh:
   m_ObjectHideFlags: 0
@@ -3769,171 +4085,6 @@ Mesh:
   m_LocalAABB:
     m_Center: {x: 4.34, y: -2.3649416, z: 0}
     m_Extent: {x: 5, y: 2.214942, z: 0}
-  m_MeshUsageFlags: 0
-  m_CookingOptions: 30
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &890077792
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 11
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: 2.4599211, y: -0.3041687, z: 0}
-      m_Extent: {x: 2.9899213, y: 0.22416878, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020000000300010004000300000005000300040006000300050003000600070002000800000000000900040001000a00020003000b00010007000c00030004000d00050005000e00060006000f000700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: 4c64ad40204107bf00000000334a7f3fdb7098bd00000080000000804c64ad40204107bf4c64ad40204107bf1c65ae4080e0ddbd000000001b499b3b43ff7f3f00000080000000801c65ae4080e0ddbd1c65ae4080e0ddbdb4e4ad4030fda2be00000000334a7f3fdb7098bd00000080000000801c65ae4080e0ddbd4c64ad40204107bf596f1d40c0dbc0bd000000001b499b3b43ff7f3f000000800000008018ae07bf00d7a3bd1c65ae4080e0ddbdb65d1d4090a003bf000000005dde9cbb40ff7fbf00000000000000804c64ad40204107bfb03400bf000000bfb03400bf000000bf000000005dde9cbb40ff7fbf0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd18ae07bf00d7a3bd0000000039627fbf16068ebd000000000000008018ae07bf00d7a3bd18ae07bf00d7a3bdb4e4ad4030fda2be00000000334a7f3fdb7098bd00000080000000801c65ae4080e0ddbd4c64ad40204107bf4c64ad40204107bf000000005dde9cbb40ff7fbf00000000000000804c64ad40204107bf4c64ad40204107bf1c65ae4080e0ddbd00000000334a7f3fdb7098bd00000080000000801c65ae4080e0ddbd1c65ae4080e0ddbd596f1d40c0dbc0bd000000001b499b3b43ff7f3f000000800000008018ae07bf00d7a3bd1c65ae4080e0ddbd18ae07bf00d7a3bd000000001b499b3b43ff7f3f000000800000008018ae07bf00d7a3bd18ae07bf00d7a3bdb65d1d4090a003bf000000005dde9cbb40ff7fbf00000000000000804c64ad40204107bfb03400bf000000bfb03400bf000000bf0000000039627fbf16068ebd0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 2.4599211, y: -0.3041687, z: 0}
-    m_Extent: {x: 2.9899213, y: 0.22416878, z: 0}
   m_MeshUsageFlags: 0
   m_CookingOptions: 30
   m_BakedConvexCollisionMesh: 
@@ -4269,397 +4420,6 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1001 &962039635
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -21.32219
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 22.07373
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5716833242501837917, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_Name
-      value: Monster (3)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5716833242501837917, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
---- !u!43 &963319530
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 11
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: 2.9729006, y: -0.29830146, z: 0}
-      m_Extent: {x: 3.5029008, y: 0.21830153, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020000000300010000000400030005000400000006000400050004000600070002000800000000000900050001000a00020003000b00010004000c00030007000d00040005000e00060006000f000700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: c4393f400c2002bf0000000012fb1bbbd1ff7fbf0000000000000080c439cf40184004bf000000bf000000bf0022cf40f8ba98be0000000037fa7f3f56ad593c00000080000000803d0acf4000d7a3bdc439cf40184004bfc439cf40184004bf0000000036fa7f3f7eb6593c0000008000000080c439cf40184004bfc439cf40184004bf3d0acf4000d7a3bd00000000000000800000803f00000080000000803d0acf4000d7a3bd3d0acf4000d7a3bd7a143e4000d7a3bd00000000000000800000803f000000800000008018ae07bf00d7a3bd3d0acf4000d7a3bd000000bf000000bf0000000012fb1bbbd1ff7fbf0000000000000080000000bf000000bf000000bf000000bf0cd703bfe07a94be0000000073597fbf3aea91bd0000000000000080000000bf000000bf18ae07bf00d7a3bd18ae07bf00d7a3bd0000000073597fbf3aea91bd000000000000008018ae07bf00d7a3bd18ae07bf00d7a3bdc439cf40184004bf0000000012fb1bbbd1ff7fbf0000000000000080c439cf40184004bfc439cf40184004bfc4393f400c2002bf0000000012fb1bbbd1ff7fbf0000000000000080c439cf40184004bf000000bf000000bf0022cf40f8ba98be0000000036fa7f3f7eb6593c00000080000000803d0acf4000d7a3bdc439cf40184004bf3d0acf4000d7a3bd0000000037fa7f3f56ad593c00000080000000803d0acf4000d7a3bd3d0acf4000d7a3bd7a143e4000d7a3bd00000000000000800000803f000000800000008018ae07bf00d7a3bd3d0acf4000d7a3bd18ae07bf00d7a3bd00000000000000800000803f000000800000008018ae07bf00d7a3bd18ae07bf00d7a3bd000000bf000000bf0000000073597fbf3aea91bd0000000000000080000000bf000000bf000000bf000000bf0cd703bfe07a94be0000000073597fbf3aea91bd0000000000000080000000bf000000bf18ae07bf00d7a3bd
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 2.9729006, y: -0.29830146, z: 0}
-    m_Extent: {x: 3.5029008, y: 0.21830153, z: 0}
-  m_MeshUsageFlags: 0
-  m_CookingOptions: 30
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &974810801
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 11
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: 2.5154, y: -0.29851627, z: 0}
-      m_Extent: {x: 3.002625, y: 0.20148373, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020000000300010004000300000004000500030004000600050006000400070002000800000000000900040001000a00020003000b00010005000c00030004000d00070006000e00050007000f000600
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: 6b89b0404026fcbe00000000a5ff7f3fb5f856bb00000080000000806b89b0404026fcbe6b89b0404026fcbea993b04000ffe3bd000000003e6d1c3bd0ff7f3f0000008000000080a993b04000ffe3bda993b04000ffe3bd8a8eb04000939abe00000000a5ff7f3fb5f856bb0000008000000080a993b04000ffe3bd6b89b0404026fcbe45862140005cd5bd000000003d6d1c3bd0ff7f3f000000800000008044d6f0be00b9c6bda993b04000ffe3bd12f220402013febe000000009d2ea43af3ff7fbf00000080000000806b89b0404026fcbe9875f9be000000bf44d6f0be00b9c6bd00000000d8c67fbf3f072b3d000000800000008044d6f0be00b9c6bd44d6f0be00b9c6bdee25f5be20d798be00000000d8c67fbf3f072b3d00000080000000809875f9be000000bf44d6f0be00b9c6bd9875f9be000000bf000000009d2ea43af3ff7fbf00000080000000809875f9be000000bf9875f9be000000bf8a8eb04000939abe00000000a5ff7f3fb5f856bb0000008000000080a993b04000ffe3bd6b89b0404026fcbe6b89b0404026fcbe000000009d2ea43af3ff7fbf00000080000000806b89b0404026fcbe6b89b0404026fcbea993b04000ffe3bd00000000a5ff7f3fb5f856bb0000008000000080a993b04000ffe3bda993b04000ffe3bd45862140005cd5bd000000003e6d1c3bd0ff7f3f000000800000008044d6f0be00b9c6bda993b04000ffe3bd44d6f0be00b9c6bd000000003d6d1c3bd0ff7f3f000000800000008044d6f0be00b9c6bd44d6f0be00b9c6bd12f220402013febe000000009d2ea43af3ff7fbf00000080000000806b89b0404026fcbe9875f9be000000bfee25f5be20d798be00000000d8c67fbf3f072b3d00000080000000809875f9be000000bf44d6f0be00b9c6bd9875f9be000000bf00000000d8c67fbf3f072b3d00000080000000809875f9be000000bf9875f9be000000bf
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 2.5154, y: -0.29851627, z: 0}
-    m_Extent: {x: 3.002625, y: 0.20148373, z: 0}
-  m_MeshUsageFlags: 0
-  m_CookingOptions: 30
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!1 &985191810
 GameObject:
   m_ObjectHideFlags: 0
@@ -4931,28 +4691,171 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
---- !u!114 &986739329 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 82556552863905360, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
-  m_PrefabInstance: {fileID: 986739328}
+--- !u!43 &1028041760
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &986739330 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5653028454564186289, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
-  m_PrefabInstance: {fileID: 986739328}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: 2.9702513, y: -0.28468752, z: 0}
+      m_Extent: {x: 3.5002515, y: 0.21531248, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: 5c0ecf40408ffabe000000003bf57f3fe17c943c00000080000000805c0ecf40408ffabe5c0ecf40408ffabefccfce4080148ebd000000000526c7baedff7f3f0000008000000080fccfce4080148ebdfccfce4080148ebd2cefce40300a8fbe000000003bf57f3fe17c943c0000008000000080fccfce4080148ebd5c0ecf40408ffabec6073f40a047fdbe0000000071c8c73aecff7fbf00000080000000805c0ecf40408ffabeb03400bf000000bf39da3d40c0f598bd000000000526c7baedff7f3f000000800000008018ae07bf00d7a3bdfccfce4080148ebdb03400bf000000bf0000000071c8c73aecff7fbf0000008000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd18ae07bf00d7a3bd0000000039627fbf16068ebd000000000000008018ae07bf00d7a3bd18ae07bf00d7a3bd2cefce40300a8fbe000000003bf57f3fe17c943c0000008000000080fccfce4080148ebd5c0ecf40408ffabe5c0ecf40408ffabe0000000071c8c73aecff7fbf00000080000000805c0ecf40408ffabe5c0ecf40408ffabefccfce4080148ebd000000003bf57f3fe17c943c0000008000000080fccfce4080148ebdfccfce4080148ebd39da3d40c0f598bd000000000526c7baedff7f3f000000800000008018ae07bf00d7a3bdfccfce4080148ebdc6073f40a047fdbe0000000071c8c73aecff7fbf00000080000000805c0ecf40408ffabeb03400bf000000bf18ae07bf00d7a3bd000000000526c7baedff7f3f000000800000008018ae07bf00d7a3bd18ae07bf00d7a3bdb03400bf000000bf0000000039627fbf16068ebd0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 2.9702513, y: -0.28468752, z: 0}
+    m_Extent: {x: 3.5002515, y: 0.21531248, z: 0}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1001 &1028046129
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4974,8 +4877,16 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4487756712048951882, guid: 57e8ec7b68e9e45ddbd5cc73c25364f2, type: 3}
+      propertyPath: debugMode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4487756712048951882, guid: 57e8ec7b68e9e45ddbd5cc73c25364f2, type: 3}
       propertyPath: viewAngle
       value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 7200822750370687276, guid: 57e8ec7b68e9e45ddbd5cc73c25364f2, type: 3}
+      propertyPath: debugMode
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7200822750370687276, guid: 57e8ec7b68e9e45ddbd5cc73c25364f2, type: 3}
       propertyPath: MoveNodes.Array.size
@@ -5364,6 +5275,171 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1539279165031085476, guid: b5e742bb914f2af40abea98c7b0709d8, type: 3}
   m_PrefabInstance: {fileID: 1094349151}
   m_PrefabAsset: {fileID: 0}
+--- !u!43 &1098444600
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: 0, y: -2.0481834, z: 0}
+      m_Extent: {x: 0.5, y: 5.698183, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: 0000003f3ce2f7c0000000000000803f0000008000000080000000800000003f3ce2f7c00000003f3ce2f7c00000003f9899694000000000000000800000803f00000080000000800000003f989969400000003f989969400000003f701503c0000000000000803f0000008000000080000000800000003f989969400000003f3ce2f7c0000000003ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c0000000bf3ce2f7c0000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000bf3ce2f7c00000000000000080000080bf0000000000000080000000bf3ce2f7c0000000bf3ce2f7c0000000bf701503c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf98996940000000bf9899694000000000000080bf000000800000008000000080000000bf98996940000000bf989969400000003f701503c0000000000000803f0000008000000080000000800000003f989969400000003f3ce2f7c00000003f3ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c00000003f3ce2f7c00000003f98996940000000000000803f0000008000000080000000800000003f989969400000003f98996940000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000003ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c0000000bf3ce2f7c0000000bf9899694000000000000000800000803f0000008000000080000000bf98996940000000bf98996940000000bf3ce2f7c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf3ce2f7c0000000bf701503c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf98996940
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: -2.0481834, z: 0}
+    m_Extent: {x: 0.5, y: 5.698183, z: 0}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!43 &1108052254
 Mesh:
   m_ObjectHideFlags: 0
@@ -5529,6 +5605,17 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!114 &1141156420 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3482432296173024574, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
+  m_PrefabInstance: {fileID: 986739328}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!43 &1141233473
 Mesh:
   m_ObjectHideFlags: 0
@@ -5847,171 +5934,6 @@ Mesh:
   m_LocalAABB:
     m_Center: {x: 2.9729006, y: -0.29830146, z: 0}
     m_Extent: {x: 3.5029008, y: 0.21830153, z: 0}
-  m_MeshUsageFlags: 0
-  m_CookingOptions: 30
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &1202723741
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 11
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: 2.9699998, y: -0.28999996, z: 0}
-      m_Extent: {x: 3.5, y: 0.21000004, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020000000300010000000400030005000400000006000400050004000600070002000800000000000900050001000a00020003000b00010004000c00030007000d00040005000e00060006000f000700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: f2ea3e40000000bf0000000000000080000080bf000000000000008088f1ce40000000bfb03400bf000000bfe2fdce40e07a94be0000000050fe7f3f0e56ebbb00000080000000803d0acf4000d7a3bd88f1ce40000000bf88f1ce40000000bf0000000050fe7f3f0243ebbb000000800000008088f1ce40000000bf88f1ce40000000bf3d0acf4000d7a3bd00000000000000800000803f00000080000000803d0acf4000d7a3bd3d0acf4000d7a3bd7a143e4000d7a3bd00000000000000800000803f000000800000008018ae07bf00d7a3bd3d0acf4000d7a3bdb03400bf000000bf0000000000000080000080bf0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd18ae07bf00d7a3bd0000000039627fbf16068ebd000000000000008018ae07bf00d7a3bd18ae07bf00d7a3bd88f1ce40000000bf0000000000000080000080bf000000000000008088f1ce40000000bf88f1ce40000000bff2ea3e40000000bf0000000000000080000080bf000000000000008088f1ce40000000bfb03400bf000000bfe2fdce40e07a94be0000000050fe7f3f0243ebbb00000080000000803d0acf4000d7a3bd88f1ce40000000bf3d0acf4000d7a3bd0000000050fe7f3f0e56ebbb00000080000000803d0acf4000d7a3bd3d0acf4000d7a3bd7a143e4000d7a3bd00000000000000800000803f000000800000008018ae07bf00d7a3bd3d0acf4000d7a3bd18ae07bf00d7a3bd00000000000000800000803f000000800000008018ae07bf00d7a3bd18ae07bf00d7a3bdb03400bf000000bf0000000039627fbf16068ebd0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 2.9699998, y: -0.28999996, z: 0}
-    m_Extent: {x: 3.5, y: 0.21000004, z: 0}
   m_MeshUsageFlags: 0
   m_CookingOptions: 30
   m_BakedConvexCollisionMesh: 
@@ -6512,171 +6434,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!43 &1314509143
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 11
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: 0, y: -0.08227444, z: 0}
-      m_Extent: {x: 0.5, y: 3.732274, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020000000300010004000300000005000300040006000300050003000600070002000800000000000900040001000a00020003000b00010007000c00030004000d00050005000e00060006000f000700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: 8077fa3e902174c000000000efff7f3f73c3bdba00000080000000808077fa3e902174c08077fa3e902174c00000003f9899694000000000000000800000803f00000080000000800000003f989969400000003f98996940c03bfd3e807fa8bd00000000efff7f3f73c3bdba00000080000000800000003f989969408077fa3e902174c0000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f9899694000b899bbb4d473c000000000829d1bbc0bfd7fbf00000000000000808077fa3e902174c04045ffbed88773c04045ffbed88773c000000000829d1bbc0bfd7fbf00000000000000804045ffbed88773c04045ffbed88773c0a0a2ffbe00e49ebd00000000000080bfe06548b900000000000000804045ffbed88773c0000000bf98996940000000bf9899694000000000000080bfe06548b90000000000000080000000bf98996940000000bf98996940c03bfd3e807fa8bd00000000efff7f3f73c3bdba00000080000000800000003f989969408077fa3e902174c08077fa3e902174c000000000829d1bbc0bfd7fbf00000000000000808077fa3e902174c08077fa3e902174c00000003f9899694000000000efff7f3f73c3bdba00000080000000800000003f989969400000003f98996940000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000bf9899694000000000000000800000803f0000008000000080000000bf98996940000000bf9899694000b899bbb4d473c000000000829d1bbc0bfd7fbf00000000000000808077fa3e902174c04045ffbed88773c04045ffbed88773c000000000000080bfe06548b900000000000000804045ffbed88773c04045ffbed88773c0a0a2ffbe00e49ebd00000000000080bfe06548b900000000000000804045ffbed88773c0000000bf98996940
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: -0.08227444, z: 0}
-    m_Extent: {x: 0.5, y: 3.732274, z: 0}
-  m_MeshUsageFlags: 0
-  m_CookingOptions: 30
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!1 &1325041481
 GameObject:
   m_ObjectHideFlags: 0
@@ -6813,6 +6570,171 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!43 &1451589121
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: 1.4844809, y: -0.25, z: 0}
+      m_Extent: {x: 1.9955251, y: 0.25, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: 853e5e40602defbe00000000b0f77f3fab7482bc0000008000000080853e5e40602defbe853e5e40602defbe6bb85e400000000000000000f7e9bdbbe6fe7f3f00000080000000806bb85e40000000006bb85e4000000000787b5e40602d6fbe00000000b0f77f3fab7482bc00000080000000806bb85e4000000000853e5e40602defbe5931be3fb096f7be00000000b97a073cc2fd7fbf0000008000000080853e5e40602defbeb03400bf000000bf7803be3f007e3dbc00000000f7e9bdbbe6fe7f3f0000008000000080ccd302bf007ebdbc6bb85e4000000000b03400bf000000bf00000000b97a073cc2fd7fbf0000008000000080b03400bf000000bfb03400bf000000bf3e8401bff0eb85be00000000e5f07fbf09e0afbc0000000000000080b03400bf000000bfccd302bf007ebdbcccd302bf007ebdbc00000000e5f07fbf09e0afbc0000000000000080ccd302bf007ebdbcccd302bf007ebdbc787b5e40602d6fbe00000000b0f77f3fab7482bc00000080000000806bb85e4000000000853e5e40602defbe853e5e40602defbe00000000b97a073cc2fd7fbf0000008000000080853e5e40602defbe853e5e40602defbe6bb85e400000000000000000b0f77f3fab7482bc00000080000000806bb85e40000000006bb85e40000000007803be3f007e3dbc00000000f7e9bdbbe6fe7f3f0000008000000080ccd302bf007ebdbc6bb85e40000000005931be3fb096f7be00000000b97a073cc2fd7fbf0000008000000080853e5e40602defbeb03400bf000000bfccd302bf007ebdbc00000000f7e9bdbbe6fe7f3f0000008000000080ccd302bf007ebdbcccd302bf007ebdbcb03400bf000000bf00000000e5f07fbf09e0afbc0000000000000080b03400bf000000bfb03400bf000000bf3e8401bff0eb85be00000000e5f07fbf09e0afbc0000000000000080b03400bf000000bfccd302bf007ebdbc
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 1.4844809, y: -0.25, z: 0}
+    m_Extent: {x: 1.9955251, y: 0.25, z: 0}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1001 &1453154942
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6874,336 +6796,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5f933876ca1084ad786fa20cb1e397d4, type: 3}
---- !u!43 &1460768008
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 11
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: 0, y: -3.6399999, z: 0}
-      m_Extent: {x: 0.5, y: 4, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: 0000003fe17af4c0000000000000803f0000008000000080000000800000003fe17af4c00000003fe17af4c00000003ff051b83e00000000000000800000803f00000080000000800000003ff051b83e0000003ff051b83e0000003fc2f568c0000000000000803f0000008000000080000000800000003ff051b83e0000003fe17af4c000000000e17af4c00000000000000080000080bf00000000000000800000003fe17af4c0000000bfe17af4c000000000f051b83e00000000000000800000803f0000008000000080000000bff051b83e0000003ff051b83e000000bfe17af4c00000000000000080000080bf0000000000000080000000bfe17af4c0000000bfe17af4c0000000bfc2f568c000000000000080bf000000800000008000000080000000bfe17af4c0000000bff051b83e000000bff051b83e00000000000080bf000000800000008000000080000000bff051b83e000000bff051b83e0000003fc2f568c0000000000000803f0000008000000080000000800000003ff051b83e0000003fe17af4c00000003fe17af4c00000000000000080000080bf00000000000000800000003fe17af4c00000003fe17af4c00000003ff051b83e000000000000803f0000008000000080000000800000003ff051b83e0000003ff051b83e00000000f051b83e00000000000000800000803f0000008000000080000000bff051b83e0000003ff051b83e00000000e17af4c00000000000000080000080bf00000000000000800000003fe17af4c0000000bfe17af4c0000000bff051b83e00000000000000800000803f0000008000000080000000bff051b83e000000bff051b83e000000bfe17af4c000000000000080bf000000800000008000000080000000bfe17af4c0000000bfe17af4c0000000bfc2f568c000000000000080bf000000800000008000000080000000bfe17af4c0000000bff051b83e
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: -3.6399999, z: 0}
-    m_Extent: {x: 0.5, y: 4, z: 0}
-  m_MeshUsageFlags: 0
-  m_CookingOptions: 30
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &1463954910
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 11
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: 0, y: -3.6399999, z: 0}
-      m_Extent: {x: 0.5, y: 4, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: 0000003fe17af4c0000000000000803f0000008000000080000000800000003fe17af4c00000003fe17af4c00000003ff051b83e00000000000000800000803f00000080000000800000003ff051b83e0000003ff051b83e0000003fc2f568c0000000000000803f0000008000000080000000800000003ff051b83e0000003fe17af4c000000000e17af4c00000000000000080000080bf00000000000000800000003fe17af4c0000000bfe17af4c000000000f051b83e00000000000000800000803f0000008000000080000000bff051b83e0000003ff051b83e000000bfe17af4c00000000000000080000080bf0000000000000080000000bfe17af4c0000000bfe17af4c0000000bfc2f568c000000000000080bf000000800000008000000080000000bfe17af4c0000000bff051b83e000000bff051b83e00000000000080bf000000800000008000000080000000bff051b83e000000bff051b83e0000003fc2f568c0000000000000803f0000008000000080000000800000003ff051b83e0000003fe17af4c00000003fe17af4c00000000000000080000080bf00000000000000800000003fe17af4c00000003fe17af4c00000003ff051b83e000000000000803f0000008000000080000000800000003ff051b83e0000003ff051b83e00000000f051b83e00000000000000800000803f0000008000000080000000bff051b83e0000003ff051b83e00000000e17af4c00000000000000080000080bf00000000000000800000003fe17af4c0000000bfe17af4c0000000bff051b83e00000000000000800000803f0000008000000080000000bff051b83e000000bff051b83e000000bfe17af4c000000000000080bf000000800000008000000080000000bfe17af4c0000000bfe17af4c0000000bfc2f568c000000000000080bf000000800000008000000080000000bfe17af4c0000000bff051b83e
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0, y: -3.6399999, z: 0}
-    m_Extent: {x: 0.5, y: 4, z: 0}
-  m_MeshUsageFlags: 0
-  m_CookingOptions: 30
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!43 &1515775597
 Mesh:
   m_ObjectHideFlags: 0
@@ -7369,6 +6961,171 @@ Mesh:
     offset: 0
     size: 0
     path: 
+--- !u!43 &1516755270
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: 0, y: -2.0481834, z: 0}
+      m_Extent: {x: 0.5, y: 5.698183, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: 0000003f3ce2f7c0000000000000803f0000008000000080000000800000003f3ce2f7c00000003f3ce2f7c00000003f9899694000000000000000800000803f00000080000000800000003f989969400000003f989969400000003f701503c0000000000000803f0000008000000080000000800000003f989969400000003f3ce2f7c0000000003ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c0000000bf3ce2f7c0000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000bf3ce2f7c00000000000000080000080bf0000000000000080000000bf3ce2f7c0000000bf3ce2f7c0000000bf701503c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf98996940000000bf9899694000000000000080bf000000800000008000000080000000bf98996940000000bf989969400000003f701503c0000000000000803f0000008000000080000000800000003f989969400000003f3ce2f7c00000003f3ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c00000003f3ce2f7c00000003f98996940000000000000803f0000008000000080000000800000003f989969400000003f98996940000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000003ce2f7c00000000000000080000080bf00000000000000800000003f3ce2f7c0000000bf3ce2f7c0000000bf9899694000000000000000800000803f0000008000000080000000bf98996940000000bf98996940000000bf3ce2f7c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf3ce2f7c0000000bf701503c000000000000080bf000000800000008000000080000000bf3ce2f7c0000000bf98996940
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: -2.0481834, z: 0}
+    m_Extent: {x: 0.5, y: 5.698183, z: 0}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1 &1526257714
 GameObject:
   m_ObjectHideFlags: 0
@@ -7453,7 +7210,337 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!43 &1534879103
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: 4.34, y: -2.3649416, z: 0}
+      m_Extent: {x: 5, y: 2.214942, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020000000300010004000300000005000300040006000300050003000600070002000800000000000900040001000a00020003000b00010007000c00030004000d00050005000e00060006000f000700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: de471541688e92c000000000d6ff7f3f384413bb0000008000000080de471541688e92c0de471541688e92c0a4701541809919be00000000000000800000803f0000008000000080a4701541809919bea4701541809919be415c1541345b17c000000000d6ff7f3f384413bb0000008000000080a4701541809919bede471541688e92c048e18a40809919be00000000000000800000803f0000008000000080c0f528bf809919bea4701541809919be60d58a40ba6992c00000000054266bbafaff7fbf0000000000000080de471541688e92c0e02727bf0c4592c0e02727bf0c4592c00000000054266bbafaff7fbf0000000000000080e02727bf0c4592c0e02727bf0c4592c0d00e28bfd81117c000000000eaff7fbff3f2d0ba0000000000000080e02727bf0c4592c0c0f528bf809919bec0f528bf809919be00000000eaff7fbff3f2d0ba0000000000000080c0f528bf809919bec0f528bf809919be415c1541345b17c000000000d6ff7f3f384413bb0000008000000080a4701541809919bede471541688e92c0de471541688e92c00000000054266bbafaff7fbf0000000000000080de471541688e92c0de471541688e92c0a4701541809919be00000000d6ff7f3f384413bb0000008000000080a4701541809919bea4701541809919be48e18a40809919be00000000000000800000803f0000008000000080c0f528bf809919bea4701541809919bec0f528bf809919be00000000000000800000803f0000008000000080c0f528bf809919bec0f528bf809919be60d58a40ba6992c00000000054266bbafaff7fbf0000000000000080de471541688e92c0e02727bf0c4592c0e02727bf0c4592c000000000eaff7fbff3f2d0ba0000000000000080e02727bf0c4592c0e02727bf0c4592c0d00e28bfd81117c000000000eaff7fbff3f2d0ba0000000000000080e02727bf0c4592c0c0f528bf809919be
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 4.34, y: -2.3649416, z: 0}
+    m_Extent: {x: 5, y: 2.214942, z: 0}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!43 &1562222001
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: 2.4599211, y: -0.3041687, z: 0}
+      m_Extent: {x: 2.9899213, y: 0.22416878, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020000000300010004000300000005000300040006000300050003000600070002000800000000000900040001000a00020003000b00010007000c00030004000d00050005000e00060006000f000700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: 4c64ad40204107bf00000000334a7f3fdb7098bd00000080000000804c64ad40204107bf4c64ad40204107bf1c65ae4080e0ddbd000000001b499b3b43ff7f3f00000080000000801c65ae4080e0ddbd1c65ae4080e0ddbdb4e4ad4030fda2be00000000334a7f3fdb7098bd00000080000000801c65ae4080e0ddbd4c64ad40204107bf596f1d40c0dbc0bd000000001b499b3b43ff7f3f000000800000008018ae07bf00d7a3bd1c65ae4080e0ddbdb65d1d4090a003bf000000005dde9cbb40ff7fbf00000000000000804c64ad40204107bfb03400bf000000bfb03400bf000000bf000000005dde9cbb40ff7fbf0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd18ae07bf00d7a3bd0000000039627fbf16068ebd000000000000008018ae07bf00d7a3bd18ae07bf00d7a3bdb4e4ad4030fda2be00000000334a7f3fdb7098bd00000080000000801c65ae4080e0ddbd4c64ad40204107bf4c64ad40204107bf000000005dde9cbb40ff7fbf00000000000000804c64ad40204107bf4c64ad40204107bf1c65ae4080e0ddbd00000000334a7f3fdb7098bd00000080000000801c65ae4080e0ddbd1c65ae4080e0ddbd596f1d40c0dbc0bd000000001b499b3b43ff7f3f000000800000008018ae07bf00d7a3bd1c65ae4080e0ddbd18ae07bf00d7a3bd000000001b499b3b43ff7f3f000000800000008018ae07bf00d7a3bd18ae07bf00d7a3bdb65d1d4090a003bf000000005dde9cbb40ff7fbf00000000000000804c64ad40204107bfb03400bf000000bfb03400bf000000bf0000000039627fbf16068ebd0000000000000080b03400bf000000bfb03400bf000000bf64f103bfe07a94be0000000039627fbf16068ebd0000000000000080b03400bf000000bf18ae07bf00d7a3bd
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 2.4599211, y: -0.3041687, z: 0}
+    m_Extent: {x: 2.9899213, y: 0.22416878, z: 0}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1586909691
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7640,232 +7727,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &1635856915
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 12.479581
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 19.648142
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5656864002899918941, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5716833242501837917, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_Name
-      value: Monster
-      objectReference: {fileID: 0}
-    - target: {fileID: 5716833242501837917, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
-      propertyPath: m_Layer
-      value: 9
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6e6eaaa73c8a046339019a577a9a7ad4, type: 3}
---- !u!43 &1657382146
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 11
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: 1.4844809, y: -0.25, z: 0}
-      m_Extent: {x: 1.9955251, y: 0.25, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: 853e5e40602defbe00000000b0f77f3fab7482bc0000008000000080853e5e40602defbe853e5e40602defbe6bb85e400000000000000000f7e9bdbbe6fe7f3f00000080000000806bb85e40000000006bb85e4000000000787b5e40602d6fbe00000000b0f77f3fab7482bc00000080000000806bb85e4000000000853e5e40602defbe5931be3fb096f7be00000000b97a073cc2fd7fbf0000008000000080853e5e40602defbeb03400bf000000bf7803be3f007e3dbc00000000f7e9bdbbe6fe7f3f0000008000000080ccd302bf007ebdbc6bb85e4000000000b03400bf000000bf00000000b97a073cc2fd7fbf0000008000000080b03400bf000000bfb03400bf000000bf3e8401bff0eb85be00000000e5f07fbf09e0afbc0000000000000080b03400bf000000bfccd302bf007ebdbcccd302bf007ebdbc00000000e5f07fbf09e0afbc0000000000000080ccd302bf007ebdbcccd302bf007ebdbc787b5e40602d6fbe00000000b0f77f3fab7482bc00000080000000806bb85e4000000000853e5e40602defbe853e5e40602defbe00000000b97a073cc2fd7fbf0000008000000080853e5e40602defbe853e5e40602defbe6bb85e400000000000000000b0f77f3fab7482bc00000080000000806bb85e40000000006bb85e40000000007803be3f007e3dbc00000000f7e9bdbbe6fe7f3f0000008000000080ccd302bf007ebdbc6bb85e40000000005931be3fb096f7be00000000b97a073cc2fd7fbf0000008000000080853e5e40602defbeb03400bf000000bfccd302bf007ebdbc00000000f7e9bdbbe6fe7f3f0000008000000080ccd302bf007ebdbcccd302bf007ebdbcb03400bf000000bf00000000e5f07fbf09e0afbc0000000000000080b03400bf000000bfb03400bf000000bf3e8401bff0eb85be00000000e5f07fbf09e0afbc0000000000000080b03400bf000000bfccd302bf007ebdbc
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 1.4844809, y: -0.25, z: 0}
-    m_Extent: {x: 1.9955251, y: 0.25, z: 0}
-  m_MeshUsageFlags: 0
-  m_CookingOptions: 30
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!43 &1677754104
 Mesh:
   m_ObjectHideFlags: 0
@@ -8051,6 +7912,182 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!43 &1785717764
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 11
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: 0, y: -3.6399999, z: 0}
+      m_Extent: {x: 0.5, y: 4, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: 0000003fe17af4c0000000000000803f0000008000000080000000800000003fe17af4c00000003fe17af4c00000003ff051b83e00000000000000800000803f00000080000000800000003ff051b83e0000003ff051b83e0000003fc2f568c0000000000000803f0000008000000080000000800000003ff051b83e0000003fe17af4c000000000e17af4c00000000000000080000080bf00000000000000800000003fe17af4c0000000bfe17af4c000000000f051b83e00000000000000800000803f0000008000000080000000bff051b83e0000003ff051b83e000000bfe17af4c00000000000000080000080bf0000000000000080000000bfe17af4c0000000bfe17af4c0000000bfc2f568c000000000000080bf000000800000008000000080000000bfe17af4c0000000bff051b83e000000bff051b83e00000000000080bf000000800000008000000080000000bff051b83e000000bff051b83e0000003fc2f568c0000000000000803f0000008000000080000000800000003ff051b83e0000003fe17af4c00000003fe17af4c00000000000000080000080bf00000000000000800000003fe17af4c00000003fe17af4c00000003ff051b83e000000000000803f0000008000000080000000800000003ff051b83e0000003ff051b83e00000000f051b83e00000000000000800000803f0000008000000080000000bff051b83e0000003ff051b83e00000000e17af4c00000000000000080000080bf00000000000000800000003fe17af4c0000000bfe17af4c0000000bff051b83e00000000000000800000803f0000008000000080000000bff051b83e000000bff051b83e000000bfe17af4c000000000000080bf000000800000008000000080000000bfe17af4c0000000bfe17af4c0000000bfc2f568c000000000000080bf000000800000008000000080000000bfe17af4c0000000bff051b83e
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0, y: -3.6399999, z: 0}
+    m_Extent: {x: 0.5, y: 4, z: 0}
+  m_MeshUsageFlags: 0
+  m_CookingOptions: 30
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
+--- !u!114 &1797176647 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1814142059579744957, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
+  m_PrefabInstance: {fileID: 986739328}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &1810646953 stripped
@@ -8323,11 +8360,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3402838726317016103, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -6.3
+      value: -5.53
       objectReference: {fileID: 0}
     - target: {fileID: 3402838726317016103, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.1
+      value: -0.19
       objectReference: {fileID: 0}
     - target: {fileID: 3402838726317016103, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
       propertyPath: m_LocalPosition.z
@@ -8361,42 +8398,38 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5373812725887706760, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
+      propertyPath: delay
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5373812725887706760, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
+      propertyPath: Count_Mental
+      value: 
+      objectReference: {fileID: 1797176647}
+    - target: {fileID: 5373812725887706760, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
+      propertyPath: mentalSlider
+      value: 
+      objectReference: {fileID: 1141156420}
+    - target: {fileID: 5373812725887706760, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
+      propertyPath: Count_Stamina
+      value: 
+      objectReference: {fileID: 850431952}
+    - target: {fileID: 5373812725887706760, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
+      propertyPath: staminaSlider
+      value: 
+      objectReference: {fileID: 520023049}
     - target: {fileID: 8827318982427012109, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 8721850722498308918, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
+    - {fileID: 67533911048328453, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 382615813667128817, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
-      insertIndex: 3
-      addedObject: {fileID: 481488476}
-    - targetCorrespondingSourceObject: {fileID: 382615813667128817, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
-      insertIndex: 4
-      addedObject: {fileID: 481488475}
-    - targetCorrespondingSourceObject: {fileID: 382615813667128817, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 481488474}
-    - targetCorrespondingSourceObject: {fileID: 382615813667128817, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 481488473}
-    - targetCorrespondingSourceObject: {fileID: 382615813667128817, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 481488483}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c24e0f83019fb466e8b6c345d8be967d, type: 3}
---- !u!114 &2042277473 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6426349351020995013, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
-  m_PrefabInstance: {fileID: 986739328}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!43 &2049437476
+--- !u!43 &2031565560
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8413,8 +8446,8 @@ Mesh:
     firstVertex: 0
     vertexCount: 16
     localAABB:
-      m_Center: {x: 0.059999943, y: -2.15, z: 0}
-      m_Extent: {x: 0.5, y: 5.5, z: 0}
+      m_Center: {x: 0, y: -0.08227444, z: 0}
+      m_Extent: {x: 0.5, y: 3.732274, z: 0}
   m_Shapes:
     vertices: []
     shapes: []
@@ -8431,7 +8464,7 @@ Mesh:
   m_KeepVertices: 1
   m_KeepIndices: 1
   m_IndexFormat: 0
-  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
+  m_IndexBuffer: 00000100020000000300010004000300000005000300040006000300050003000600070002000800000000000900040001000a00020003000b00010007000c00030004000d00050005000e00060006000f000700
   m_VertexData:
     serializedVersion: 3
     m_VertexCount: 16
@@ -8493,7 +8526,7 @@ Mesh:
       format: 0
       dimension: 0
     m_DataSize: 704
-    _typelessdata: 285c0f3fcdccf4c0000000000000803f000000800000008000000080285c0f3fcdccf4c0285c0f3fcdccf4c0285c0f3f6666564000000000000000800000803f0000008000000080285c0f3f66665640285c0f3f66665640285c0f3f9a9909c0000000000000803f000000800000008000000080285c0f3f66665640285c0f3fcdccf4c080c2753dcdccf4c00000000000000080000080bf0000000000000080285c0f3fcdccf4c0b047e1becdccf4c080c2753d6666564000000000000000800000803f0000008000000080b047e1be66665640285c0f3f66665640b047e1becdccf4c00000000000000080000080bf0000000000000080b047e1becdccf4c0b047e1becdccf4c0b047e1be9a9909c000000000000080bf000000800000008000000080b047e1becdccf4c0b047e1be66665640b047e1be6666564000000000000080bf000000800000008000000080b047e1be66665640b047e1be66665640285c0f3f9a9909c0000000000000803f000000800000008000000080285c0f3f66665640285c0f3fcdccf4c0285c0f3fcdccf4c00000000000000080000080bf0000000000000080285c0f3fcdccf4c0285c0f3fcdccf4c0285c0f3f66665640000000000000803f000000800000008000000080285c0f3f66665640285c0f3f6666564080c2753d6666564000000000000000800000803f0000008000000080b047e1be66665640285c0f3f6666564080c2753dcdccf4c00000000000000080000080bf0000000000000080285c0f3fcdccf4c0b047e1becdccf4c0b047e1be6666564000000000000000800000803f0000008000000080b047e1be66665640b047e1be66665640b047e1becdccf4c000000000000080bf000000800000008000000080b047e1becdccf4c0b047e1becdccf4c0b047e1be9a9909c000000000000080bf000000800000008000000080b047e1becdccf4c0b047e1be66665640
+    _typelessdata: 8077fa3e902174c000000000efff7f3f73c3bdba00000080000000808077fa3e902174c08077fa3e902174c00000003f9899694000000000000000800000803f00000080000000800000003f989969400000003f98996940c03bfd3e807fa8bd00000000efff7f3f73c3bdba00000080000000800000003f989969408077fa3e902174c0000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f9899694000b899bbb4d473c000000000829d1bbc0bfd7fbf00000000000000808077fa3e902174c04045ffbed88773c04045ffbed88773c000000000829d1bbc0bfd7fbf00000000000000804045ffbed88773c04045ffbed88773c0a0a2ffbe00e49ebd00000000000080bfe06548b900000000000000804045ffbed88773c0000000bf98996940000000bf9899694000000000000080bfe06548b90000000000000080000000bf98996940000000bf98996940c03bfd3e807fa8bd00000000efff7f3f73c3bdba00000080000000800000003f989969408077fa3e902174c08077fa3e902174c000000000829d1bbc0bfd7fbf00000000000000808077fa3e902174c08077fa3e902174c00000003f9899694000000000efff7f3f73c3bdba00000080000000800000003f989969400000003f98996940000000009899694000000000000000800000803f0000008000000080000000bf989969400000003f98996940000000bf9899694000000000000000800000803f0000008000000080000000bf98996940000000bf9899694000b899bbb4d473c000000000829d1bbc0bfd7fbf00000000000000808077fa3e902174c04045ffbed88773c04045ffbed88773c000000000000080bfe06548b900000000000000804045ffbed88773c04045ffbed88773c0a0a2ffbe00e49ebd00000000000080bfe06548b900000000000000804045ffbed88773c0000000bf98996940
   m_CompressedMesh:
     m_Vertices:
       m_NumItems: 0
@@ -8547,8 +8580,8 @@ Mesh:
       m_BitSize: 0
     m_UVInfo: 0
   m_LocalAABB:
-    m_Center: {x: 0.059999943, y: -2.15, z: 0}
-    m_Extent: {x: 0.5, y: 5.5, z: 0}
+    m_Center: {x: 0, y: -0.08227444, z: 0}
+    m_Extent: {x: 0.5, y: 3.732274, z: 0}
   m_MeshUsageFlags: 0
   m_CookingOptions: 30
   m_BakedConvexCollisionMesh: 
@@ -8561,7 +8594,18 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!43 &2080260172
+--- !u!114 &2042277473 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6426349351020995013, guid: d1e5159d61e09dd41988b41fa777fde0, type: 3}
+  m_PrefabInstance: {fileID: 986739328}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!43 &2090128004
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8836,336 +8880,6 @@ Transform:
   - {fileID: 985191811}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &2130949148
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 11
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: 4.34, y: -2.3649416, z: 0}
-      m_Extent: {x: 5, y: 2.214942, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020000000300010004000300000005000300040006000300050003000600070002000800000000000900040001000a00020003000b00010007000c00030004000d00050005000e00060006000f000700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: de471541688e92c000000000d6ff7f3f384413bb0000008000000080de471541688e92c0de471541688e92c0a4701541809919be00000000000000800000803f0000008000000080a4701541809919bea4701541809919be415c1541345b17c000000000d6ff7f3f384413bb0000008000000080a4701541809919bede471541688e92c048e18a40809919be00000000000000800000803f0000008000000080c0f528bf809919bea4701541809919be60d58a40ba6992c00000000054266bbafaff7fbf0000000000000080de471541688e92c0e02727bf0c4592c0e02727bf0c4592c00000000054266bbafaff7fbf0000000000000080e02727bf0c4592c0e02727bf0c4592c0d00e28bfd81117c000000000eaff7fbff3f2d0ba0000000000000080e02727bf0c4592c0c0f528bf809919bec0f528bf809919be00000000eaff7fbff3f2d0ba0000000000000080c0f528bf809919bec0f528bf809919be415c1541345b17c000000000d6ff7f3f384413bb0000008000000080a4701541809919bede471541688e92c0de471541688e92c00000000054266bbafaff7fbf0000000000000080de471541688e92c0de471541688e92c0a4701541809919be00000000d6ff7f3f384413bb0000008000000080a4701541809919bea4701541809919be48e18a40809919be00000000000000800000803f0000008000000080c0f528bf809919bea4701541809919bec0f528bf809919be00000000000000800000803f0000008000000080c0f528bf809919bec0f528bf809919be60d58a40ba6992c00000000054266bbafaff7fbf0000000000000080de471541688e92c0e02727bf0c4592c0e02727bf0c4592c000000000eaff7fbff3f2d0ba0000000000000080e02727bf0c4592c0e02727bf0c4592c0d00e28bfd81117c000000000eaff7fbff3f2d0ba0000000000000080e02727bf0c4592c0c0f528bf809919be
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 4.34, y: -2.3649416, z: 0}
-    m_Extent: {x: 5, y: 2.214942, z: 0}
-  m_MeshUsageFlags: 0
-  m_CookingOptions: 30
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &2139224089
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 11
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: 6.9379463, y: -0.30566025, z: 0}
-      m_Extent: {x: 7.467947, y: 0.22566032, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020003000100000003000400010005000400030006000400050004000600070002000800000000000900030001000a00020004000b00010003000c00050007000d00040005000e00060006000f000700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: 0d5d6641a00408bf00000000e7f37f3ff8609dbc00000080000000800d5d6641a00408bf0d5d6641a00408bf8a7e664100a0d8bd00000000d82ee23ae7ff7f3f00000080000000808a7e664100a0d8bd8a7e664100a0d8bdcc6d6641a018a3be00000000eaf37f3f93579dbc00000080000000808a7e664100a0d8bd0d5d6641a00408bf0d5dde40500204bf00000000e7c709bbdaff7fbf00000000000000800d5d6641a00408bf000000bf000000bfa803de40803bbebd00000000d92ee23ae7ff7f3f000000800000008018ae07bf00d7a3bd8a7e664100a0d8bd000000bf000000bf00000000e7c709bbdaff7fbf0000000000000080000000bf000000bf000000bf000000bf0cd703bfe07a94be0000000073597fbf3aea91bd0000000000000080000000bf000000bf18ae07bf00d7a3bd18ae07bf00d7a3bd0000000073597fbf3aea91bd000000000000008018ae07bf00d7a3bd18ae07bf00d7a3bdcc6d6641a018a3be00000000e7f37f3ff8609dbc00000080000000808a7e664100a0d8bd0d5d6641a00408bf0d5d6641a00408bf00000000e7c709bbdaff7fbf00000000000000800d5d6641a00408bf0d5d6641a00408bf8a7e664100a0d8bd00000000eaf37f3f93579dbc00000080000000808a7e664100a0d8bd8a7e664100a0d8bda803de40803bbebd00000000d82ee23ae7ff7f3f000000800000008018ae07bf00d7a3bd8a7e664100a0d8bd0d5dde40500204bf00000000e7c709bbdaff7fbf00000000000000800d5d6641a00408bf000000bf000000bf18ae07bf00d7a3bd00000000d92ee23ae7ff7f3f000000800000008018ae07bf00d7a3bd18ae07bf00d7a3bd000000bf000000bf0000000073597fbf3aea91bd0000000000000080000000bf000000bf000000bf000000bf0cd703bfe07a94be0000000073597fbf3aea91bd0000000000000080000000bf000000bf18ae07bf00d7a3bd
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 6.9379463, y: -0.30566025, z: 0}
-    m_Extent: {x: 7.467947, y: 0.22566032, z: 0}
-  m_MeshUsageFlags: 0
-  m_CookingOptions: 30
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!1001 &8481741635071834516
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9649,10 +9363,6 @@ SceneRoots:
   - {fileID: 2121581606}
   - {fileID: 1453154942}
   - {fileID: 1028046129}
-  - {fileID: 1635856915}
-  - {fileID: 297837743}
-  - {fileID: 103886628}
-  - {fileID: 962039635}
   - {fileID: 8481741635071834516}
   - {fileID: 1988093605}
   - {fileID: 1094349151}

--- a/Assets/CreatureAI/Scripts/Creatures/Avoider.cs
+++ b/Assets/CreatureAI/Scripts/Creatures/Avoider.cs
@@ -36,8 +36,9 @@ namespace Creature
 
             actions.Add(new CreatureAvoidingAction(this));
 
+            
+            pathFinder = new PathFinder(map, mapOffset);
             AddLightOnMap();
-            pathFinder = new PathFinder(lightAppliedMap, mapOffset);
             actions[(int)status].Play();
             StartCoroutine(MoveOnPath());
         }
@@ -46,14 +47,12 @@ namespace Creature
         protected override List<Node> FindPath(float x, float y)
         {
             AddLightOnMap();
-            pathFinder.SetMap(lightAppliedMap);
             return base.FindPath(x, y);
         }
 
         protected override void SetRandomPath()
         {
             AddLightOnMap();
-            pathFinder.SetMap(lightAppliedMap);
             base.SetRandomPath();
         }
 
@@ -69,6 +68,7 @@ namespace Creature
             status = CreatureStatus.PATROL;
             actions[(int)status].Play();
         }
+        GameObject[] lastSpotLights = new GameObject[0];
 
         protected void AddLightOnMap()
         {
@@ -78,7 +78,17 @@ namespace Creature
             }
 
             lightAppliedMap = DeepCopy(map);
+            
             GameObject[] spotLights = GameObject.FindGameObjectsWithTag("Light");
+
+            if (CompareGameObjectArrays.AreGameObjectArraysEqual(lastSpotLights, spotLights))
+            {
+                return;
+            }
+            else
+            { 
+                lastSpotLights = spotLights;
+            } 
 
             foreach (GameObject spotLight in spotLights)
             {
@@ -110,6 +120,8 @@ namespace Creature
                     catch { }
                     
                 }
+
+                pathFinder.SetMap(lightAppliedMap);
             }
         }
 

--- a/Assets/CreatureAI/Scripts/Creatures/Avoider.cs
+++ b/Assets/CreatureAI/Scripts/Creatures/Avoider.cs
@@ -72,16 +72,34 @@ namespace Creature
 
         protected void AddLightOnMap()
         {
+            if (debugMode)
+            {
+                Debug.Log(gameObject.name + " | " + this.name + " : Apply Light On Map...");
+            }
+
             lightAppliedMap = DeepCopy(map);
             GameObject[] spotLights = GameObject.FindGameObjectsWithTag("Light");
 
             foreach (GameObject spotLight in spotLights)
             {
                 Light2D light = spotLight.GetComponentInChildren<Light2D>();
-                List<(int, int)> points = PointsInCircle(
+                if (!light.gameObject.active)
+                {
+                    continue;
+                }
+                List<(int, int)> points;
+                try
+                {
+                    points = PointsInCircle(
                     (int)spotLight.transform.position.x,
                     (int)spotLight.transform.position.y,
                     (int)light.pointLightOuterRadius);
+                }
+                catch
+                {
+                    continue;
+                }
+                
 
                 foreach ((int, int) point in points)
                 {
@@ -154,6 +172,11 @@ namespace Creature
             }
 
             return newArray;
+        }
+
+        protected void Update()
+        {
+            base.Update();
         }
     }
 }

--- a/Assets/CreatureAI/Scripts/Creatures/Creature.cs
+++ b/Assets/CreatureAI/Scripts/Creatures/Creature.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Unity.VisualScripting;
 using UnityEditor.Experimental.GraphView;
 using UnityEngine;
@@ -61,7 +62,7 @@ namespace Creature{
 
     public class Creature : Actor
     {
-        [SerializeField] bool debugMode = true;
+        [SerializeField] protected bool debugMode = true;
 
         private Detector detector;
 
@@ -112,6 +113,11 @@ namespace Creature{
 
         public virtual IEnumerator PatrolAction()
         {
+            if (debugMode)
+            {
+                Debug.Log(gameObject.name + " | " + this.name + " : Patrol...");
+            }
+
             speed = minSpeed;
             DetectPlayer();
             yield return new WaitForSeconds(0.1f);
@@ -120,6 +126,11 @@ namespace Creature{
 
         public virtual IEnumerator PursuitAction()
         {
+            if (debugMode)
+            {
+                Debug.Log(gameObject.name + " | " + this.name + " : Pursuit...");
+            }
+
             speed = maxSpeed;
             DetectPlayer();
             yield return new WaitForSeconds(0.1f);
@@ -129,6 +140,11 @@ namespace Creature{
 
         public virtual IEnumerator AlertedAction()
         {
+            if (debugMode)
+            {
+                Debug.Log(gameObject.name + " | " + this.name + " : Alerted...");
+            }
+
             speed = minSpeed;
             DetectPlayer();
             detector.setLookingAngle(detector.getLookingAngle() + 10f);
@@ -147,6 +163,11 @@ namespace Creature{
 
         protected void DetectPlayer()
         {
+            if (debugMode)
+            {
+                Debug.Log(gameObject.name + " | " + this.name + " : Detecting Player...");
+            }
+
             List<Collider2D> detectedPlayerCollider = detector.DetectByView();
             if (detectedPlayerCollider.Count > 0)
             {
@@ -201,6 +222,12 @@ namespace Creature{
         {
             while(true)
             {
+                if (debugMode)
+                {
+                    Debug.Log(gameObject.name + " | " + this.name + " : is Moving");
+                    lastStatus = status;
+                }
+
                 yield return new WaitForSeconds(0.01f);
 
                 Node node;
@@ -255,6 +282,11 @@ namespace Creature{
         {
             if (collision.CompareTag("Player"))
             {
+                if (debugMode)
+                {
+                    Debug.Log(gameObject.name + " | " + this.name + " : Kill Player...");
+                }
+
                 Destroy(collision.gameObject);
             }
         }
@@ -266,6 +298,20 @@ namespace Creature{
                 Mathf.RoundToInt(vector.y),
                 Mathf.RoundToInt(vector.z)
             );
+        }
+
+        CreatureStatus lastStatus = CreatureStatus.PATROL;
+
+        protected void Update()
+        {
+            if (debugMode)
+            {
+                if (status != lastStatus)
+                {
+                    Debug.Log(gameObject.name + " | " + this.name + " : updated status to " + status.ToString());
+                    lastStatus = status;
+                }
+            }
         }
     }
 }

--- a/Assets/CreatureAI/Scripts/Creatures/Stunnee.cs
+++ b/Assets/CreatureAI/Scripts/Creatures/Stunnee.cs
@@ -1,8 +1,5 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using System;
-using UnityEngine.Rendering.Universal;
 
 namespace Creature
 {
@@ -43,6 +40,11 @@ namespace Creature
         protected override void OnTriggerEnter2D(Collider2D collision)
         {
             base.OnTriggerEnter2D(collision);
+        }
+
+        protected void Update()
+        {
+            base.Update();
         }
     }
 }

--- a/Assets/CreatureAI/Scripts/Util/CompareGameObjectArrays.cs
+++ b/Assets/CreatureAI/Scripts/Util/CompareGameObjectArrays.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CompareGameObjectArrays : MonoBehaviour
+{
+    public static bool AreGameObjectArraysEqual(GameObject[] array1, GameObject[] array2)
+    {
+        if (array1.Length != array2.Length)
+            return false;
+
+
+        Dictionary<GameObject, int> dict1 = new Dictionary<GameObject, int>();
+
+        foreach (GameObject obj in array1)
+        {
+            if (dict1.ContainsKey(obj))
+                dict1[obj]++;
+            else
+                dict1[obj] = 1;
+        }
+
+        foreach (GameObject obj in array2)
+        {
+            if (dict1.ContainsKey(obj))
+            {
+                dict1[obj]--;
+                if (dict1[obj] == 0)
+                    dict1.Remove(obj);
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        return dict1.Count == 0;
+    }
+}

--- a/Assets/CreatureAI/Scripts/Util/CompareGameObjectArrays.cs.meta
+++ b/Assets/CreatureAI/Scripts/Util/CompareGameObjectArrays.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46e1632a592f54ae0a531cf142ba5b51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CreatureAI/Scripts/Util/PathFinder.cs
+++ b/Assets/CreatureAI/Scripts/Util/PathFinder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using UnityEngine;
 
 [Serializable]
@@ -78,7 +79,9 @@ public class PathFinder
 
     public void SetMap(int[,] newMap)
     {
+        Debug.Log("Map Updated");
         this.map = newMap;
+        nodes = new Node[width, height];
     }
 
     public List<Node> FindPath(Node startNode, Node endNode)
@@ -192,6 +195,8 @@ public class PathFinder
             computingCounter++;
             if (computingCounter > maxComputing)
             {
+                Debug.Log("RandomPath Not Found");
+                
                 return null;
             }
             int tempRandomNum = random.Next(0, 5);

--- a/Assets/PasswordSystem/Scripts/Locker.cs
+++ b/Assets/PasswordSystem/Scripts/Locker.cs
@@ -12,7 +12,7 @@ public class Locker : PasswordObject
     public override void Unlock()
     {
         base.Unlock();
-        Instantiate(item);
+        Instantiate(item, (Vector3)transform.position + Vector3.down, Quaternion.identity);
         
     }
 


### PR DESCRIPTION
closed #92

### 설명
- Avoider, Stunnee가 SpotLight가 바뀔 때 그 변경사항이 Path Finder에 적용을 하지 못 하는 문제가 있었습니다.
- CompareGameObjectArrays 라는 Util Class를 구현해서 GameObject Array를 비교하는 기능을 구현했습니다.
- 위 함수를 사용해서 SpotLights에 변경이 있을 때 그 Light들을 맵에 적용하여 길찾기 알고리즘에 사용할 수 있도록 수정했습니다.
- 그 또한 PathFinder에서 map을 참조하는 것이 아닌 nodes를 참조하기 때문에 map이 변경 되었을 때 nodes는 초기화 되지 않에 map이 적용되지 않는 문제가 있었습니다.
   - 그렇기에 Map의 Setter가 호출되었을 때 nodes를 초기화 해주는 로직을 추가했습니다.
   - 다음과 같은 변경사항 때문에 게임의 자원 사용이 증가 할 것이기에 SpotLight의 변경 사항을 체크하는 로직을 추가했습니다.

### 체크리스트
- [x] 코드가 잘 작동하는지 확인했습니까?
- [x] 코드 스타일이 일관된지 확인했습니까?
- [x] 문서가 업데이트되었는지 확인했습니까?
