### PR TITLE
fix: 입력 정지, 씬 전환, 퍼즐 진행 불가 등 전반 버그 수정

### DIFF
--- a/Assets/Scripts/CharacterStat.cs
+++ b/Assets/Scripts/CharacterStat.cs
@@ -67,7 +67,7 @@ public class CharacterStat : MonoBehaviour, ISceneChangeListener
         count_Stamina = staminaBar.Find("Count_Stamina").GetComponent<TextMeshProUGUI>();
         PortalManager.Instance.SetSceneChangeListener(this);
         audioSource = transform.Find("PlayerStatusSoundController").GetComponent<AudioSource>();
-        audioSource.clip = SoundManager.Instance.soundSources.GetByName("Heartbeat").Value.sound;
+        audioSource.clip = SoundManager.Instance.soundSources.GetClipByName("Heartbeat");
         SetStats();
         UpdateStats();
         mentalCoroutine = StartCoroutine(ReduceMental());
@@ -124,6 +124,15 @@ public class CharacterStat : MonoBehaviour, ISceneChangeListener
     }
 
     /// <summary>
+    /// Adds to mental, clamped to [0, maxMental], and refreshes the UI.
+    /// </summary>
+    public void ChangeMental(float amount)
+    {
+        curMental = Mathf.Clamp(curMental + amount, 0, maxMental);
+        UpdateStats();
+    }
+
+    /// <summary>
     /// Coroutine that continuously reduces mental stat when player is in darkness.
     /// Triggers hallucination effects (visual overlay and heartbeat audio) when mental drops below warning threshold.
     /// </summary>
@@ -131,16 +140,18 @@ public class CharacterStat : MonoBehaviour, ISceneChangeListener
     {
         yield return new WaitUntil(() => hallucinationSpriteRenderer != null);
 
-        while (curMental > 0)
-        {   
+        // Loops forever: quitting at curMental == 0 left the drain permanently dead
+        // once mental was restored by an item.
+        while (true)
+        {
             yield return new WaitForSecondsRealtime(delay);
-            if (!isOnLight)
+            if (!isOnLight && curMental > 0)
             {
-                curMental -= reduceAmount;
+                ChangeMental(-reduceAmount);
                 // Increase heartbeat pitch as mental decreases
                 audioSource.pitch = 1 + (float)(((maxMental * MENTAL_WARNING_RATE) - curMental) / (maxMental * MENTAL_WARNING_RATE));
                 // Gradually increase hallucination overlay opacity
-                float alpha = (float)(((maxMental * MENTAL_WARNING_RATE) - curMental) / (maxMental * MENTAL_WARNING_RATE)) / 3;
+                float alpha = Mathf.Clamp01((((maxMental * MENTAL_WARNING_RATE) - curMental) / (maxMental * MENTAL_WARNING_RATE)) / 3);
                 yield return new WaitUntil(() => hallucinationSpriteRenderer != null);
                 Color hallucinationColor = hallucinationSpriteRenderer.color;
                 hallucinationColor.a = alpha;

--- a/Assets/Scripts/Dialogue/NpcDialogue.cs
+++ b/Assets/Scripts/Dialogue/NpcDialogue.cs
@@ -7,11 +7,9 @@ namespace Dialogue
         [SerializeField] string npcType;
         [SerializeField] NpcDialogueData npcDialogueData;
 
-        protected override void OnTriggerEnter2D(Collider2D other)
-        {
-            NpcDialogueController.Instance.ShowDialogue(npcDialogueData.GetDialogues(npcType));
-        }
-
+        // OnTriggerEnter2D is left to the base class: it shows the prompt and stores the
+        // collider ActOnTrigger needs. Overriding it skipped both and fired the dialogue
+        // on walk-in instead of on the interaction key.
         protected override void ActOnTrigger(Collider2D other)
         {
             NpcDialogueController.Instance.ShowDialogue(npcDialogueData.GetDialogues(npcType));

--- a/Assets/Scripts/Dialogue/NpcDialogueController.cs
+++ b/Assets/Scripts/Dialogue/NpcDialogueController.cs
@@ -53,6 +53,12 @@ namespace Dialogue
         void ISceneChangeListener.OnSceneChange()
         {
             dialogueImages =  ReferenceManager.Instance.FindComponentByName<ReferableObject>("DialogueImages");
+            if (dialogueImages == null)
+            {
+                Debug.LogWarning("DialogueImages not registered - dialogue is disabled in this scene");
+                dialogueImage = null;
+                return;
+            }
 
             dialogueImage = dialogueImages.transform.Find("DialogueBackground").gameObject;
             dialogueCharacter = dialogueImages.transform.Find("LucyDialogueImage").gameObject;
@@ -66,9 +72,21 @@ namespace Dialogue
             };
         }
 
+        private Coroutine displayCoroutine;
+
         public void ShowDialogue(string[] dialogues, float delayBetweenDialogues = 1.5f) // 두 문장 이상 출력
         {
-            StartCoroutine(DisplayDialogues(dialogues, delayBetweenDialogues));
+            // A null array (unknown npcType) used to throw inside the coroutine with
+            // timeScale already at 0, freezing the game for good.
+            if (dialogues == null || dialogues.Length == 0 || dialogueImage == null)
+            {
+                return;
+            }
+            if (displayCoroutine != null)
+            {
+                return;
+            }
+            displayCoroutine = StartCoroutine(DisplayDialogues(dialogues, delayBetweenDialogues));
         }
 
         public void ShowDialogue(string dialogue) // 한 문장 출력
@@ -92,6 +110,7 @@ namespace Dialogue
             dialogueImage.SetActive(false);
             dialogueCharacter.SetActive(false);
             Time.timeScale = 1f;
+            displayCoroutine = null;
         }
 
         private IEnumerator TypeDialogue(string dialogue)

--- a/Assets/Scripts/Event/EventObject.cs
+++ b/Assets/Scripts/Event/EventObject.cs
@@ -12,12 +12,13 @@ namespace Event
         {
             PortalManager.Instance.SetSceneChangeListener(this);
             eventSoundController = GetComponent<EventSoundController>();
-            EventScheduler.Instance.eventObjects.Add("FirstMeetNpcEventObject", this);
+            // Indexer, not Add: a second EventObject (or a scene reload) threw on a duplicate key.
+            EventScheduler.Instance.eventObjects["FirstMeetNpcEventObject"] = this;
         }
 
         public void PlaySound()
         {
-            eventSoundController.PlaySound(SoundManager.Instance.soundSources.GetByName("OpenTheDoor2").Value.sound, true);
+            eventSoundController.PlaySound(SoundManager.Instance.soundSources.GetClipByName("OpenTheDoor2"), true);
         }
         public void StopSound()
         {

--- a/Assets/Scripts/Event/NpcEventController.cs
+++ b/Assets/Scripts/Event/NpcEventController.cs
@@ -21,7 +21,7 @@ namespace Event
         private void Start()
         {
             guardObj = GameObject.Find("Guard");
-            guard = guardObj.GetComponent<Guard>(); 
+            guard = guardObj == null ? null : guardObj.GetComponent<Guard>();
 
             player = Character.Instance.gameObject;
 
@@ -33,7 +33,10 @@ namespace Event
         {
             if (other.CompareTag("Player") && !isAlreadyTalk)
             {
-                EventScheduler.Instance.eventObjects["FirstMeetNpcEventObject"].StopSound();
+                if (EventScheduler.Instance.eventObjects.TryGetValue("FirstMeetNpcEventObject", out EventObject eventObject))
+                {
+                    eventObject.StopSound();
+                }
                 NpcDialogueController.Instance.ShowDialogue(npcDialogueData.GetDialogues(npcType));
                 isAlreadyTalk = true;
             }
@@ -49,9 +52,15 @@ namespace Event
         private void StartNpcEvent()
         {
             InputManager.Instance.SetMovementState(false);
-            guard.StopPatrol();
+            if (guard != null)
+            {
+                guard.StopPatrol();
+            }
             //startdialog
-            barricade.SetActive(false);
+            if (barricade != null)
+            {
+                barricade.SetActive(false);
+            }
             StartCoroutine(WaitAndFinishNpcEvent());
         }
 
@@ -67,7 +76,10 @@ namespace Event
         private void FinishNpcEvent()
         {
             InputManager.Instance.SetMovementState(true);
-            guard.StartPatrol();
+            if (guard != null)
+            {
+                guard.StartPatrol();
+            }
             Destroy(this);
         }
     }

--- a/Assets/Scripts/InputSystem/InputManager.cs
+++ b/Assets/Scripts/InputSystem/InputManager.cs
@@ -32,6 +32,7 @@ namespace InputSystem
 
         private readonly Dictionary<ActionCode, bool> keyDownBools = new Dictionary<ActionCode, bool>();
         private readonly Dictionary<ActionCode, bool> keyDownBoolsForListener = new Dictionary<ActionCode, bool>();
+        private readonly Dictionary<ActionCode, bool> keyUpBoolsForListener = new Dictionary<ActionCode, bool>();
         private readonly Dictionary<ActionCode, Coroutine> keyDownCounterCoroutine = new Dictionary<ActionCode, Coroutine>();
         private readonly Dictionary<ActionCode, bool> keyActiveFlags = new Dictionary<ActionCode, bool>();
         private readonly Dictionary<ActionCode, KeyCode> keyMappings = new Dictionary<ActionCode, KeyCode>()
@@ -55,9 +56,15 @@ namespace InputSystem
             return (int)action >= (int)ActionCode.MoveUp && (int)action <= (int)ActionCode.MoveLeft;
         }
 
+        protected override void Awake()
+        {
+            base.Awake();
+            // Init in Awake: other scripts read key states from their own Start().
+            InitKeyDownDictionarys();
+        }
+
         private void Start()
         {
-            InitKeyDownDictionarys();
             StartCoroutine(CallListenersCoroutine());
         }
 
@@ -194,6 +201,13 @@ namespace InputSystem
                         }
                         keyDownCounterCoroutine[action] = StartCoroutine(KeyDownCounter(action));
                     }
+
+                    // GetKeyUp is only true for a single frame, so it has to be latched here
+                    // instead of polled from CallListenersCoroutine.
+                    if (Input.GetKeyUp(keyMappings[action]))
+                    {
+                        keyUpBoolsForListener[action] = true;
+                    }
                 }
             }
 
@@ -201,7 +215,15 @@ namespace InputSystem
 
         public void SetKeyListener(IKeyInputListener listener)
         {
-            inputListeners.Add(listener);
+            if (!inputListeners.Contains(listener))
+            {
+                inputListeners.Add(listener);
+            }
+        }
+
+        public void RemoveKeyListener(IKeyInputListener listener)
+        {
+            inputListeners.Remove(listener);
         }
 
         private void InitKeyDownDictionarys()
@@ -212,6 +234,7 @@ namespace InputSystem
                 keyDownCounterCoroutine.Add(action, null);
                 keyActiveFlags.Add(action, true);
                 keyDownBoolsForListener.Add(action, false);
+                keyUpBoolsForListener.Add(action, false);
             }
         }
 
@@ -233,8 +256,10 @@ namespace InputSystem
                         {
                             CallOnKeyListeners(action);
                         }
-                        else if (Input.GetKeyUp(keyMappings[action]))
+
+                        if (keyUpBoolsForListener[action])
                         {
+                            keyUpBoolsForListener[action] = false;
                             CallOnKeyUpListeners(action);
                         }
                     }
@@ -244,31 +269,47 @@ namespace InputSystem
         }
 
 
+        /// <summary>
+        /// Calls every registered listener, dropping the ones whose GameObject was destroyed
+        /// (scene change) and swallowing listener exceptions.
+        /// Without this a single dead listener kills CallListenersCoroutine and all input stops.
+        /// Iterates backwards so removals and registrations during the call are safe.
+        /// </summary>
+        private void CallListeners(ActionCode action, Action<IKeyInputListener> call)
+        {
+            for (int i = inputListeners.Count - 1; i >= 0; i--)
+            {
+                IKeyInputListener listener = inputListeners[i];
+                if (listener == null || (listener is MonoBehaviour behaviour && behaviour == null))
+                {
+                    inputListeners.RemoveAt(i);
+                    continue;
+                }
+
+                try
+                {
+                    call(listener);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning(e);
+                }
+            }
+        }
+
         private void CallOnKeyListeners(ActionCode action)
         {
-            foreach (IKeyInputListener listener in inputListeners)
-            {
-                listener.OnKey(action);
-
-            }
+            CallListeners(action, listener => listener.OnKey(action));
         }
 
         private void CallOnKeyDownListeners(ActionCode action)
         {
-            foreach (IKeyInputListener listener in inputListeners)
-            {
-                listener.OnKeyDown(action);
-
-            }
+            CallListeners(action, listener => listener.OnKeyDown(action));
         }
 
         private void CallOnKeyUpListeners(ActionCode action)
         {
-            foreach (IKeyInputListener listener in inputListeners)
-            {
-                listener.OnKeyUp(action);
-
-            }
+            CallListeners(action, listener => listener.OnKeyUp(action));
         }
     }
 }

--- a/Assets/Scripts/Interactable/Furniture.cs
+++ b/Assets/Scripts/Interactable/Furniture.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Interactable
@@ -8,7 +9,15 @@ namespace Interactable
 
         protected override void ActOnTrigger(Collider2D other)
         {
-            FurnitureController.Instance.furnitures[furniture.furnitureType].Interact(this);
+            Dictionary<FurnitureType, Furnitures> furnitures = FurnitureController.Instance.furnitures;
+            if (furniture == null || furnitures == null)
+            {
+                return;
+            }
+            if (furnitures.TryGetValue(furniture.furnitureType, out Furnitures target))
+            {
+                target.Interact(this);
+            }
         }
     }
 }

--- a/Assets/Scripts/Interactable/FurnitureController.cs
+++ b/Assets/Scripts/Interactable/FurnitureController.cs
@@ -111,11 +111,17 @@ namespace Interactable
         {
             this.flashlight = flashlight;
             this.drawerImages = drawerImages;
-            spriteRenderer = GameObject.Find("Drawer").GetComponent<SpriteRenderer>();
+            GameObject drawer = GameObject.Find("Drawer");
+            spriteRenderer = drawer == null ? null : drawer.GetComponent<SpriteRenderer>();
         }
 
         public override void Interact(Furniture furniture)
         {
+            if (spriteRenderer == null || drawerImages.Count < 2)
+            {
+                return;
+            }
+
             if (flashlight == null || !flashlight.activeSelf)
             {
                 if (spriteRenderer.sprite == drawerImages[0])

--- a/Assets/Scripts/InteractableObject.cs
+++ b/Assets/Scripts/InteractableObject.cs
@@ -7,15 +7,29 @@ public abstract class InteractableObject : MonoBehaviour, IKeyInputListener
     private Collider2D other;
     protected virtual void Start()
     {
-        TextObject.SetActive(false);
+        if (TextObject != null)
+        {
+            TextObject.SetActive(false);
+        }
         InputManager.Instance.SetKeyListener(this);
+    }
+
+    protected virtual void OnDestroy()
+    {
+        if (InputManager.Instance != null)
+        {
+            InputManager.Instance.RemoveKeyListener(this);
+        }
     }
 
     protected virtual void OnTriggerEnter2D(Collider2D other)
     {
         if (other.gameObject.tag.Equals("Player"))
         {
-            TextObject.SetActive(true);
+            if (TextObject != null)
+            {
+                TextObject.SetActive(true);
+            }
             this.other = other;
         }
     }
@@ -33,8 +47,11 @@ public abstract class InteractableObject : MonoBehaviour, IKeyInputListener
     {
         if (other.gameObject.tag.Equals("Player"))
         {
-            TextObject.SetActive(false);
-            this.other = null;  
+            if (TextObject != null)
+            {
+                TextObject.SetActive(false);
+            }
+            this.other = null;
         }
     }
 

--- a/Assets/Scripts/Lucy/CharacterMove.cs
+++ b/Assets/Scripts/Lucy/CharacterMove.cs
@@ -10,6 +10,7 @@ namespace Lucy
         private Rigidbody2D playerRb;
         private Animator Anim;
         public float playerMoveSpeed = 150f;
+        private float resumeMoveSpeed = 150f;
         private ActorSoundController soundController;
         
         private const float RUN_SPEED_MULTIPLIER = 1.5f;
@@ -23,6 +24,7 @@ namespace Lucy
             soundController = transform.Find("FootsoundController").GetComponent<ActorSoundController>();
             playerRb = GetComponent<Rigidbody2D>();
             Anim = GetComponent<Animator>();
+            resumeMoveSpeed = playerMoveSpeed;
         }
 
         void FixedUpdate()
@@ -67,14 +69,19 @@ namespace Lucy
         }
         public void StopMovement()
         {
-            playerMoveSpeed = 0f; 
+            if (playerMoveSpeed > 0f)
+            {
+                // Remember the inspector value instead of resuming at a hardcoded 150.
+                resumeMoveSpeed = playerMoveSpeed;
+            }
+            playerMoveSpeed = 0f;
             Anim.SetFloat("MoveX", 0);
             Anim.SetFloat("MoveY", 0);
         }
 
         public void ResumeMovement()
         {
-            playerMoveSpeed = 150f;
+            playerMoveSpeed = resumeMoveSpeed;
         }
     }
 }

--- a/Assets/Scripts/Lucy/HandLightRotator.cs
+++ b/Assets/Scripts/Lucy/HandLightRotator.cs
@@ -28,17 +28,20 @@ namespace Lucy
             inputManager.SetKeyListener(this);
             if(handlightObject == null)
             {
-                Debug.LogError("HandLight Object�� ���� �����ϴ�! ������ player ������ �ִ� ������Ʈ�� ã�Ƽ� �������� �ּ���!");
-            }    
+                Debug.LogError("HandLight Object is not assigned! Please find the HandLight object under the player and assign it.");
+            }
         }
         void IKeyInputListener.OnKey(ActionCode action)
         {
-            if (inputManager.isMoveActioncode(action))
+            if (handlightObject != null && inputManager.isMoveActioncode(action))
             {
                 Vector3 direction = InputManager.Instance.GetMoveVector();
                 float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
                 handlightObject.transform.rotation = Quaternion.Euler(0, 0, angle - 90);
-                detector.SetLookingDirection(direction);
+                if (detector != null)
+                {
+                    detector.SetLookingDirection(direction);
+                }
             }
         }
     }

--- a/Assets/Scripts/Lucy/HandLightSwitch.cs
+++ b/Assets/Scripts/Lucy/HandLightSwitch.cs
@@ -14,7 +14,7 @@ namespace Lucy
         }
         public void TurnOnHandLight()
         {
-            if ( FlashLight.instance.battery>=0)
+            if (FlashLight.instance.battery > 0)
             {
                 handlightObject.SetActive(true);
             }

--- a/Assets/Scripts/Password_Object/PasswordSystem.cs
+++ b/Assets/Scripts/Password_Object/PasswordSystem.cs
@@ -21,8 +21,9 @@ namespace Password_Object
 
         private void Awake()
         {
-            text = gameObject.GetComponentInChildren<TMP_Text>();
-            passwordCanvas = gameObject.GetComponentInChildren<Canvas>();
+            // includeInactive: the password canvas is disabled most of the time.
+            text = gameObject.GetComponentInChildren<TMP_Text>(true);
+            passwordCanvas = gameObject.GetComponentInChildren<Canvas>(true);
         }
 
         void Start()
@@ -53,6 +54,12 @@ namespace Password_Object
 
         private void InitButtonsOnClick()
         {
+            if (buttons.Count < 12)
+            {
+                Debug.LogError("PasswordSystem needs 12 buttons: 0-9, clear, confirm");
+                return;
+            }
+
             for (int i = 0; i < 10; i++) {
                 int index = i;
                 buttons[i].onClick.AddListener(() =>
@@ -71,7 +78,7 @@ namespace Password_Object
 
             buttons[11].onClick.AddListener(() =>
             {
-                if (password == currentPassword)
+                if (password == currentPassword && passwordObject != null)
                 {
                     passwordObject.Unlock();
                     passwordCanvas.gameObject.SetActive(false);

--- a/Assets/Scripts/Portal/CameraEffector.cs
+++ b/Assets/Scripts/Portal/CameraEffector.cs
@@ -5,93 +5,54 @@ using UnityEngine.UI;
 
 namespace Portal
 {
-    public enum CameraEffectType
-    {
-        NONE,
-        FADE_OUT,
-        FADE_IN,
-    }
-
-    public interface ICameraEffect
-    {
-        void OnEffect();
-    }
-
-    public abstract class CameraEffect : ICameraEffect
-    {
-
-        public CameraEffectType cameraEffectType;
-        protected float duration;
-
-        public CameraEffect(CameraEffectType type, float second)
-        {
-            cameraEffectType = type;
-            duration = second;
-        }
-
-        public void OnEffect()
-        {
-            throw new System.NotImplementedException();
-        }
-    }
-
-    public class FadeOutCameraEffect : CameraEffect
-    {
-        public FadeOutCameraEffect(CameraEffectType type, float second) : base(type, second)
-        {
-        }
-    }
-
     public class CameraEffector : SingletonObject<CameraEffector>
     {
         Image fadeImage;
         const float FADE_DURATION = 2f;
-
-        List<CameraEffect> cameraEffectList;
-
-        float curTime = 0;
-        float curAlpha = 0;
 
         private void Start()
         {
             fadeImage = transform.GetChild(0).GetChild(0).GetComponent<Image>();
         }
 
+        // unscaledDeltaTime: dialogues and puzzles set timeScale to 0, which used to make
+        // a fade never finish and hang the scene transition on a black screen.
         public IEnumerator FadeOut()
         {
-            curTime = 0;
+            float curTime = 0;
 
             while (curTime < FADE_DURATION)
             {
                 yield return null;
-                curTime += Time.deltaTime;
-                curAlpha = curTime / FADE_DURATION;
-                fadeImage.color = new Color(0, 0, 0, curAlpha);
+                curTime += Time.unscaledDeltaTime;
+                SetFadeAlpha(curTime / FADE_DURATION);
             }
         }
         public IEnumerator FadeIn()
         {
-            curTime = FADE_DURATION;
+            float curTime = FADE_DURATION;
 
             while (curTime > 0)
             {
                 yield return null;
-                curTime -= Time.deltaTime;
-                curAlpha = curTime / FADE_DURATION;
-                fadeImage.color = new Color(0, 0, 0, curAlpha);
+                curTime -= Time.unscaledDeltaTime;
+                SetFadeAlpha(curTime / FADE_DURATION);
             }
+        }
+
+        private void SetFadeAlpha(float alpha)
+        {
+            if (fadeImage == null)
+            {
+                return;
+            }
+            fadeImage.color = new Color(0, 0, 0, Mathf.Clamp01(alpha));
         }
 
         public IEnumerator FadeOutIn()
         {
             yield return FadeOut();
             yield return FadeIn();
-        }
-
-        public void AddCameraEffect(CameraEffect cameraEffect)
-        {
-            cameraEffectList.Add(cameraEffect);
-            cameraEffect.OnEffect();
         }
 
     }

--- a/Assets/Scripts/Portal/Portal.cs
+++ b/Assets/Scripts/Portal/Portal.cs
@@ -8,7 +8,14 @@ namespace Portal
 
         private void OnTriggerEnter2D(Collider2D collision)
         {
-            StartCoroutine(PortalManager.Instance.TransitScene(portalID));
+            if (!collision.CompareTag("Player"))
+            {
+                return;
+            }
+
+            // Run on PortalManager: this Portal is destroyed by the scene load, which would
+            // abort the coroutine before the player is repositioned and the screen faded back in.
+            PortalManager.Instance.StartCoroutine(PortalManager.Instance.TransitScene(portalID));
         }
     }
 }

--- a/Assets/Scripts/Portal/PortalManager.cs
+++ b/Assets/Scripts/Portal/PortalManager.cs
@@ -19,6 +19,8 @@ namespace Portal
 
         private readonly List<ISceneChangeListener> listeners = new List<ISceneChangeListener>();
 
+        private bool isTransiting;
+
         private void Start()
         {
             DontDestroyOnLoad(this);
@@ -31,7 +33,10 @@ namespace Portal
         /// <param name="listener">The listener to register</param>
         public void SetSceneChangeListener(ISceneChangeListener listener)
         {
-            listeners.Add(listener);
+            if (!listeners.Contains(listener))
+            {
+                listeners.Add(listener);
+            }
         }
 
         /// <summary>
@@ -41,8 +46,17 @@ namespace Portal
         private IEnumerator CallOnSceneChange()
         {
             yield return new WaitForSeconds(CALL_LISTENER_DELAY);
-            foreach (ISceneChangeListener listener in listeners)
+            // Backwards: listeners destroyed by the scene load are dropped here, and a listener
+            // registering another one during the callback cannot invalidate the iteration.
+            for (int i = listeners.Count - 1; i >= 0; i--)
             {
+                ISceneChangeListener listener = listeners[i];
+                if (listener == null || (listener is MonoBehaviour behaviour && behaviour == null))
+                {
+                    listeners.RemoveAt(i);
+                    continue;
+                }
+
                 try
                 {
                     listener.OnSceneChange();
@@ -51,7 +65,7 @@ namespace Portal
                 {
                     Debug.LogWarning(e.Message);
                 }
-            
+
             }
         }
 
@@ -62,13 +76,21 @@ namespace Portal
         /// <param name="portalID">The ID of the portal to use for transition</param>
         public IEnumerator TransitScene(PortalID portalID)
         {
-            yield return CameraEffector.Instance.FadeOut();
             PortalData portalData = portalDataList.GetPortalDataByID(portalID);
-            SceneData sceneData = sceneDataList.GetSceneDataByID(portalData.sceneID);
+            SceneData sceneData = portalData == null ? null : sceneDataList.GetSceneDataByID(portalData.sceneID);
+            if (sceneData == null || isTransiting)
+            {
+                yield break;
+            }
+            isTransiting = true;
+
+            yield return CameraEffector.Instance.FadeOut();
             SceneManager.LoadScene(sceneData.sceneName);
+            yield return null; // LoadScene only takes effect at the end of the frame
             StartCoroutine(CallOnSceneChange());
             Character.Instance.transform.position = portalData.destination;
-            StartCoroutine(CameraEffector.Instance.FadeIn());
+            yield return CameraEffector.Instance.FadeIn();
+            isTransiting = false;
         }
 
     }

--- a/Assets/Scripts/Puzzle/PuzzleManager2F.cs
+++ b/Assets/Scripts/Puzzle/PuzzleManager2F.cs
@@ -48,6 +48,11 @@ namespace Puzzle
                     bridge.SetActive(isOns[bridgeComponent.bridgeID]);
                 }
             }
+            if (player == null || square == null)
+            {
+                return;
+            }
+
             if(player.transform.position.x > -40f && SceneManager.GetActiveScene().name == "Puzzle_2F_Beaver")
             {
                 square.transform.position = new Vector3(12.06f, 0.13f, 0f);
@@ -61,6 +66,11 @@ namespace Puzzle
         private IEnumerator CallActivateBridge(BridgeID bridgeID)
         {
             yield return new WaitForSeconds(CallBridgeActiveDelay);
+            isOns[bridgeID] = true;
+            if (bridges == null)
+            {
+                yield break;
+            }
             foreach (GameObject bridge in bridges)
             {
                 Bridge_Puzzle2F bridgeComponent = bridge.GetComponent<Bridge_Puzzle2F>();

--- a/Assets/Scripts/Puzzle/PuzzleSwitch2F.cs
+++ b/Assets/Scripts/Puzzle/PuzzleSwitch2F.cs
@@ -5,15 +5,12 @@ namespace Puzzle
     public class PuzzleSwitch2F : MonoBehaviour
     {
         [SerializeField] BridgeID bridgeID;
-        private GameObject player;
-        // Start is called before the first frame update
-        void Start()
-        {
-            player = GameObject.Find("Player");
-        }
+
         private void OnTriggerEnter2D(Collider2D other)
         {
-            if (other.gameObject == player)
+            // Tag instead of GameObject.Find("Player"): the name lookup missed the player
+            // whenever the collider sat on a child object or the object was named differently.
+            if (other.CompareTag("Player"))
             {
                 PuzzleManager2F.Instance.ActivateBridge(bridgeID);
             }

--- a/Assets/Scripts/Scripts_Creatures/CreatureManager.cs
+++ b/Assets/Scripts/Scripts_Creatures/CreatureManager.cs
@@ -45,14 +45,24 @@ namespace Scripts_Creatures
         {
             ReferenceManager.Instance.SetReferableObject("CreatureManager", this, false);
             mapBuilder = gameObject.GetComponent<MapBuilder>();
-            tilemaps.Add(GameObject.Find("Floor_tilemap").GetComponent<Tilemap>());
-            //tilemaps.Add(GameObject.Find("Furniture_grid").GetComponent<Tilemap>());
+
+            GameObject floorTilemap = GameObject.Find("Floor_tilemap");
+            if (floorTilemap == null)
+            {
+                Debug.LogWarning("Floor_tilemap not found - creature pathfinding is disabled in this scene");
+                return;
+            }
+
+            // OnEnable runs again on every re-enable: rebuild instead of appending duplicates.
+            tilemaps.Clear();
+            tilemaps.Add(floorTilemap.GetComponent<Tilemap>());
             InitMap();
             InitPathFinders();
         }
 
         void InitPathFinders()
         {
+            pathFinders.Clear();
             pathFinders.Add(new PathFinder(GetDoorAppliedMap(), mapOffset, debugMode));
             pathFinders.Add(new PathFinder(GetDoorAndLightAppliedMap(), mapOffset, debugMode));
         }
@@ -106,7 +116,7 @@ namespace Scripts_Creatures
                     int offsetAppliedX = position.x - mapOffset.x;
                     int offsetAppliedY = position.y - mapOffset.y;
 
-                    if (offsetAppliedX > 0 && offsetAppliedX < map.GetLength(0) && offsetAppliedY > 0 && offsetAppliedY < map.GetLength(1))
+                    if (offsetAppliedX >= 0 && offsetAppliedX < map.GetLength(0) && offsetAppliedY >= 0 && offsetAppliedY < map.GetLength(1))
                     {
                         if (!isReversed && tileBase != null)
                         {
@@ -124,6 +134,10 @@ namespace Scripts_Creatures
 
         public void UpdateMap()
         {
+            if (pathFinders.Count < 2)
+            {
+                return;
+            }
             pathFinders[(int)PathFinderType.DEFAULT].SetMap(GetDoorAppliedMap());
             pathFinders[(int)PathFinderType.AVOIDER].SetMap(GetDoorAndLightAppliedMap());
         }

--- a/Assets/Scripts/Scripts_Creatures/Creatures/Creature.cs
+++ b/Assets/Scripts/Scripts_Creatures/Creatures/Creature.cs
@@ -15,7 +15,7 @@ namespace Scripts_Creatures.Creatures{
         PURSUIT = 1,   // 추적 - 플레이어를 감지하고 추적 중
         ALERTED = 2,   // 경계 - 플레이어를 놓쳤으나 주변을 경계하며 탐색
         AVOIDING = 3,  // 회피 - 특정 크리처가 빛을 피함
-        STUNNED = 3,   // 기절 - 일시적으로 행동 불가
+        STUNNED = 4,   // 기절 - 일시적으로 행동 불가
     }
 
     /// <summary>
@@ -41,6 +41,8 @@ namespace Scripts_Creatures.Creatures{
         protected CreatureStatus status;
 
         private Coroutine alertedCounterCoroutine;
+
+        protected Coroutine moveOnPathCoroutine;
 
         private LayerMask soundTargetMask;
 
@@ -74,7 +76,7 @@ namespace Scripts_Creatures.Creatures{
             soundTargetMask = LayerMask.GetMask("Door") | LayerMask.GetMask("Player");
             soundDetector.SetTargetMask(soundTargetMask);
             StartCoroutine(CreatureUpdate());
-            StartCoroutine(MoveOnPath());
+            moveOnPathCoroutine = StartCoroutine(MoveOnPath());
         }
 
         public IEnumerator AlertedCounter()
@@ -253,7 +255,20 @@ namespace Scripts_Creatures.Creatures{
             while (true)
             {
                 yield return new WaitForSecondsRealtime(ACTION_DELAY);
-                actions[status].Update();
+                // An unhandled status or a throwing action used to kill this coroutine,
+                // freezing the creature for the rest of the run.
+                if (!actions.ContainsKey(status))
+                {
+                    continue;
+                }
+                try
+                {
+                    actions[status].Update();
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning(e);
+                }
             }
         }
 

--- a/Assets/Scripts/Scripts_Creatures/Creatures/Guard.cs
+++ b/Assets/Scripts/Scripts_Creatures/Creatures/Guard.cs
@@ -22,13 +22,17 @@ namespace Scripts_Creatures.Creatures
         protected override void PatrolStart()
         {
             base.PatrolStart();
+            if (MoveNodes.Count == 0)
+            {
+                return;
+            }
             targetPosition.Set(MoveNodes[patrolMoveFlag].X, MoveNodes[patrolMoveFlag].Y, 0);
             SetPathToPosition(targetPosition);
         }
 
         protected override void PatrolUpdate()
         {
-            if (isArrived)
+            if (isArrived && MoveNodes.Count > 0)
             {
                 patrolMoveFlag++;
                 if (patrolMoveFlag >= MoveNodes.Count)
@@ -55,8 +59,19 @@ namespace Scripts_Creatures.Creatures
 
         public void StopPatrol()
         {
+            if (!isPatrolling)
+            {
+                return;
+            }
             isPatrolling = false;
-            StopAllCoroutines();
+            // StopAllCoroutines also killed CreatureUpdate, which StartPatrol never restarted,
+            // leaving the guard brain-dead after the NPC event.
+            if (moveOnPathCoroutine != null)
+            {
+                StopCoroutine(moveOnPathCoroutine);
+                moveOnPathCoroutine = null;
+            }
+            path = null;
         }
 
         public void StartPatrol()
@@ -64,7 +79,7 @@ namespace Scripts_Creatures.Creatures
             if (!isPatrolling)
             {
                 isPatrolling = true;
-                StartCoroutine(MoveOnPath());
+                moveOnPathCoroutine = StartCoroutine(MoveOnPath());
             }
         }
     }

--- a/Assets/Scripts/Scripts_Creatures/HandLight.cs
+++ b/Assets/Scripts/Scripts_Creatures/HandLight.cs
@@ -27,14 +27,10 @@ namespace Scripts_Creatures
                 List<Collider2D> targets = detector.DetectByView();
                 foreach (Collider2D target in targets)
                 {
-                    try
+                    avoider = target.GetComponent<Avoider>();
+                    if (avoider != null)
                     {
-                        avoider = target.GetComponent<Avoider>();
                         avoider.OnDetectedByHandLight(transform.position);
-                    }
-                    catch
-                    {
-                        continue;
                     }
                 }
             }

--- a/Assets/Scripts/Scripts_Creatures/Util/PathFinder.cs
+++ b/Assets/Scripts/Scripts_Creatures/Util/PathFinder.cs
@@ -40,6 +40,16 @@ namespace Scripts_Creatures.Util
             {
                 compare = HCost.CompareTo(other.HCost);
             }
+            // Tie-break on coordinates: SortedSet treats compare == 0 as "same element",
+            // so equal-cost nodes on different tiles were being dropped from the open set.
+            if (compare == 0)
+            {
+                compare = X.CompareTo(other.X);
+            }
+            if (compare == 0)
+            {
+                compare = Y.CompareTo(other.Y);
+            }
             return compare;
         }
 
@@ -127,16 +137,19 @@ namespace Scripts_Creatures.Util
                         continue;
                     }
                     int newMovementCostToNeighbor = currentNode.GCost + GetDistance(currentNode, neighbor);
-                    if (newMovementCostToNeighbor < neighbor.GCost || !openSet.Contains(neighbor))
+                    bool isInOpenSet = openSet.Contains(neighbor);
+                    if (newMovementCostToNeighbor < neighbor.GCost || !isInOpenSet)
                     {
+                        // Costs are the sort key, so the node has to leave the set before
+                        // they change - mutating it in place corrupts the SortedSet.
+                        if (isInOpenSet)
+                        {
+                            openSet.Remove(neighbor);
+                        }
                         neighbor.GCost = newMovementCostToNeighbor;
                         neighbor.HCost = GetDistance(neighbor, endNode);
                         neighbor.Parent = currentNode;
-
-                        if (!openSet.Contains(neighbor))
-                        {
-                            openSet.Add(neighbor);
-                        }
+                        openSet.Add(neighbor);
                     }
                 }
             }
@@ -168,6 +181,10 @@ namespace Scripts_Creatures.Util
         private Node GetNode(int x, int y)
         {
             Node tempNode;
+            if (x - mapOffset.x < 0 || x - mapOffset.x >= width || y - mapOffset.y < 0 || y - mapOffset.y >= height)
+            {
+                return null;
+            }
             if (this.nodes[x - mapOffset.x, y - mapOffset.y] == null)
             {
                 tempNode = new Node(x, y, map[x - mapOffset.x, y - mapOffset.y] == 1);
@@ -204,18 +221,21 @@ namespace Scripts_Creatures.Util
                         continue;
 
                     float gCost = currentNode.GCost + GetDistance(currentNode, neighbor);
+                    bool isInOpenSet = openSet.Contains(neighbor);
 
-                    if (!openSet.Contains(neighbor))
-                    {
-                        openSet.Add(neighbor);
-                    } else if (gCost >= neighbor.GCost)
+                    if (isInOpenSet && gCost >= neighbor.GCost)
                     {
                         continue;
+                    }
+                    if (isInOpenSet)
+                    {
+                        openSet.Remove(neighbor);
                     }
 
                     neighbor.GCost = (int)gCost;
                     neighbor.HCost = (int) Vector3.Angle(direction, (new Vector3(neighbor.X - startNode.X, neighbor.Y - startNode.Y)).normalized);
                     neighbor.Parent = currentNode;
+                    openSet.Add(neighbor);
                 }
             }
 
@@ -230,9 +250,14 @@ namespace Scripts_Creatures.Util
 
             Node lastNode = startNode;
 
-            List<Node> neighbors = GetNeighbors(startNode);
             System.Random random = new System.Random();
-            int currentDirection = directions.FindIndex(t => t.Item1 == Mathf.Sign(direction.x) && t.Item2 == Mathf.Sign(direction.y));
+            // Mathf.Sign(0) is 1, so signs never matched an axis-aligned direction here.
+            int currentDirection = directions.FindIndex(
+                t => t.Item1 == Mathf.RoundToInt(direction.x) && t.Item2 == Mathf.RoundToInt(direction.y));
+            if (currentDirection < 0)
+            {
+                currentDirection = 0;
+            }
             for (int i = 0; i < nodeLen; i++)
             {
                 computingCounter++;
@@ -263,7 +288,7 @@ namespace Scripts_Creatures.Util
                     directions[currentDirection].Item1 + lastNode.X,
                     directions[currentDirection].Item2 + lastNode.Y
                 );
-                if (!node.IsWalkable)
+                if (node == null || !node.IsWalkable)
                 {
                     i--;
                     continue;
@@ -281,7 +306,7 @@ namespace Scripts_Creatures.Util
             List<Node> path = new List<Node>();
             Node currentNode = endNode;
 
-            while (currentNode != startNode)
+            while (currentNode != null && currentNode != startNode)
             {
                 path.Add(currentNode);
                 currentNode = currentNode.Parent;

--- a/Assets/Scripts/Scripts_Creatures/Util/SoundDetector.cs
+++ b/Assets/Scripts/Scripts_Creatures/Util/SoundDetector.cs
@@ -30,6 +30,10 @@ namespace Scripts_Creatures.Util
             {
                 float distance = Vector3.Distance(transform.position, target.transform.position);
                 AudioSource source = target.GetComponentInChildren<AudioSource>();
+                if (source == null)
+                {
+                    continue;
+                }
 
                 if (distance < source.maxDistance && source.isPlaying)
                 {

--- a/Assets/Scripts/Scripts_door/DoorObject.cs
+++ b/Assets/Scripts/Scripts_door/DoorObject.cs
@@ -18,7 +18,10 @@ namespace Scripts_door
 
         public bool CheckCanOpen()
         {
-            return !isLocked || Array.Exists(Inventory.instance.slots,itemSlot => itemSlot.item.itemId == keyId);
+            // itemSlot.item is null on every empty slot - checking it first avoids a crash
+            // whenever a locked door is used with a non-full inventory.
+            return !isLocked || Array.Exists(Inventory.instance.slots,
+                itemSlot => itemSlot.item != null && itemSlot.item.itemId == keyId);
         }
     }
 
@@ -35,7 +38,10 @@ namespace Scripts_door
             {
                 door.SetActive(!door.activeSelf);
                 soundController.PlaySound(door.activeSelf);
-                creatureManager.UpdateMap();
+                if (creatureManager != null)
+                {
+                    creatureManager.UpdateMap();
+                }
             }
         }
 

--- a/Assets/Scripts/Slide_Puzzle/PuzzleInteract.cs
+++ b/Assets/Scripts/Slide_Puzzle/PuzzleInteract.cs
@@ -29,6 +29,9 @@ namespace Slide_Puzzle
 
         protected override void Start()
         {
+            // Without base.Start() this never registered as a key listener,
+            // so ActOnTrigger was never called and the puzzle could not be opened.
+            base.Start();
             text.SetActive(false);
             slicePuzzleCanvas.gameObject.SetActive(false);
             clearPuzzleImage.SetActive(false);
@@ -44,12 +47,11 @@ namespace Slide_Puzzle
 
         protected override void OnTriggerEnter2D(Collider2D other)
         {
-            if (!isClear)
+            // base tracks the collider that ActOnTrigger needs.
+            base.OnTriggerEnter2D(other);
+            if (!isClear && other.gameObject.tag.Equals("Player"))
             {
-                if (other.gameObject.tag.Equals("Player"))
-                {
-                    text.SetActive(true);
-                }
+                text.SetActive(true);
             }
         }
 

--- a/Assets/Scripts/SpotLight.cs
+++ b/Assets/Scripts/SpotLight.cs
@@ -31,9 +31,15 @@ public class SpotLight : MonoBehaviour
             targets = detector.DetectByView();
             foreach (Collider2D target in targets)
             {
-                if (target.CompareTag("Player"))
+                if (!target.CompareTag("Player"))
                 {
-                    target.gameObject.GetComponent<CharacterStat>().OnSpotLight();
+                    continue;
+                }
+                // CharacterStat can sit on a parent of the collider.
+                CharacterStat characterStat = target.GetComponentInParent<CharacterStat>();
+                if (characterStat != null)
+                {
+                    characterStat.OnSpotLight();
                 }
             }
         } 

--- a/Assets/Scripts/invertoryAndItem/FlashLight.cs
+++ b/Assets/Scripts/invertoryAndItem/FlashLight.cs
@@ -38,47 +38,19 @@ namespace invertoryAndItem
             TurnOffUi();
         }
 
-        void Update()
-        {
-
-        }
-
         public void SetUi()
         {
-            for (int i = 0; i < activeBatteries.Length; i++)
-            {
-                if (i < battery)
-                {
-                    activeBatteries[i].gameObject.SetActive(true);
-                    inactiveBatteries[i].gameObject.SetActive(false);
-                }
-                else
-                {
-                    activeBatteries[i].gameObject.SetActive(false);
-                    inactiveBatteries[i].gameObject.SetActive(true);
-                }
-            }
+            UpdateUi();
         }
 
         public void UpdateUi()
         {
-            for (int i = 0; i < activeBatteries.Length; i++)
+            int count = Mathf.Min(activeBatteries.Length, inactiveBatteries.Length);
+            for (int i = 0; i < count; i++)
             {
-                if (i < battery)
-                {
-                    activeBatteries[i].gameObject.SetActive(true);
-                    inactiveBatteries[i].gameObject.SetActive(false);
-                }
-                else
-                {
-                    activeBatteries[i].gameObject.SetActive(false);
-                    inactiveBatteries[i].gameObject.SetActive(true);
-                }
-            }
-
-            if (battery <= 0)
-            {
-
+                bool isCharged = i < battery;
+                activeBatteries[i].gameObject.SetActive(isCharged);
+                inactiveBatteries[i].gameObject.SetActive(!isCharged);
             }
         }
 
@@ -105,7 +77,10 @@ namespace invertoryAndItem
             if (battery <= 0)
             {
                 battery = 0;
-                StopConsumeBattery();
+                UpdateUi();
+                // This coroutine is finishing anyway - calling StopConsumeBattery() here
+                // stopped itself mid-way, so just drop the handle.
+                batteryCoroutine = null;
                 CharacterStat.instance.StartMentalReduce();
                 HandLightSwitch.instance.TurnOffHandLight();
             }

--- a/Assets/Scripts/invertoryAndItem/Inventory.cs
+++ b/Assets/Scripts/invertoryAndItem/Inventory.cs
@@ -173,6 +173,11 @@ namespace invertoryAndItem
 
         public void OnUseButton()
         {
+            if (selectedItem == null || selectedItem.item == null)
+            {
+                return;
+            }
+
             if (selectedItem.item.type == ItemType.CONSUMABLE)
             {
                 for (int i = 0; i < selectedItem.item.consumables.Length; i++)
@@ -180,29 +185,23 @@ namespace invertoryAndItem
                     switch (selectedItem.item.consumables[i].type)
                     {
                         case ConsumableType.Battery:
-                            if (FlashLight.instance.battery <= 0)
+                            bool wasEmpty = FlashLight.instance.battery <= 0;
+                            FlashLight.instance.battery += 2;
+                            if (wasEmpty)
                             {
+                                // Order matters: the switch refuses to turn on with an empty battery.
                                 HandLightSwitch.instance.TurnOnHandLight();
-                                FlashLight.instance.battery += 2;
                                 FlashLight.instance.StartConsumeBattery();
                                 CharacterStat.instance.StopMentalReduce();
-                                FlashLight.instance.UpdateUi();
-                                break;
                             }
-                            else
-                            {
-                                FlashLight.instance.battery += 2;
-                                FlashLight.instance.UpdateUi();
-                                break;
-                            }
+                            FlashLight.instance.UpdateUi();
+                            break;
                         case ConsumableType.CurMental:
-                            CharacterStat.instance.curMental += 10;
-                            CharacterStat.instance.UpdateStats();
+                            CharacterStat.instance.ChangeMental(10);
                             break;
                         case ConsumableType.MaxMental:
                             CharacterStat.instance.maxMental += 10;
-                            CharacterStat.instance.curMental += 10;
-                            CharacterStat.instance.UpdateStats();
+                            CharacterStat.instance.ChangeMental(10);
                             break;
                     }
                 }
@@ -217,7 +216,7 @@ namespace invertoryAndItem
         }
         public void OnEquipButton()
         {
-            if (selectedItem != null && selectedItem.item.type == ItemType.EQUIPABLE)
+            if (selectedItem?.item != null && selectedItem.item.type == ItemType.EQUIPABLE)
             {
                 Equip(selectedItemIndex); 
             }
@@ -269,7 +268,7 @@ namespace invertoryAndItem
 
         public void OnUnEquipButton()
         {
-            if (selectedItem != null && selectedItem.item.type == ItemType.EQUIPABLE)
+            if (selectedItem?.item != null && selectedItem.item.type == ItemType.EQUIPABLE)
             {
                 UnEquip(selectedItemIndex);
             }
@@ -311,7 +310,12 @@ namespace invertoryAndItem
             {
                 if (uidSlot[selectedItemIndex].equipped) UnEquip(selectedItemIndex);
                 selectedItem.item = null;
+                selectedItem.quantity = 0;
                 ClearSelectItemWindow();
+                // Leaving the buttons up let the player use an item that no longer exists.
+                useButton.SetActive(false);
+                equipButton.SetActive(false);
+                unEquipButton.SetActive(false);
             }
 
             UpdateUI();

--- a/Assets/Scripts/invertoryAndItem/ItemObject.cs
+++ b/Assets/Scripts/invertoryAndItem/ItemObject.cs
@@ -16,8 +16,12 @@ namespace invertoryAndItem
 
         protected override void ActOnTrigger(Collider2D other)
         {
-            Inventory.instance.AddItem(item);
-            Object.Destroy(gameObject);
+            // Only remove the pickup if it actually made it into the inventory,
+            // otherwise a full inventory silently deletes the item.
+            if (Inventory.instance.AddItem(item))
+            {
+                Object.Destroy(gameObject);
+            }
         }
     }
 }

--- a/Assets/Scripts/soundSystem]/ActorSoundController.cs
+++ b/Assets/Scripts/soundSystem]/ActorSoundController.cs
@@ -28,7 +28,7 @@ namespace soundSystem_
         {
             walkSounds = soundManager.soundSources.GetSoundSourcesByNameContain("Walk");
             runSounds = soundManager.soundSources.GetSoundSourcesByNameContain("Run");
-            footstepSoundCount = Mathf.Min(walkSounds.Count, walkSounds.Count);
+            footstepSoundCount = Mathf.Min(walkSounds.Count, runSounds.Count);
         }
 
         IEnumerator FootSoundPlay()
@@ -49,6 +49,10 @@ namespace soundSystem_
         public void StartFootstepSoundPlay(bool isRun)
         {
             _isRun = isRun;
+            if (footstepSoundCount == 0)
+            {
+                return;
+            }
             if (_footstepSoundCoroutine == null)
             {
                 _footstepSoundCoroutine = StartCoroutine(FootSoundPlay());

--- a/Assets/Scripts/soundSystem]/SoundManager.cs
+++ b/Assets/Scripts/soundSystem]/SoundManager.cs
@@ -11,10 +11,9 @@ namespace soundSystem_
             base.Awake();
             if (audioSource == null)
             {
-                try
-                {
-                    audioSource = gameObject.GetComponent<AudioSource>();
-                } catch
+                // GetComponent returns null instead of throwing, so the old try/catch never fired.
+                audioSource = gameObject.GetComponent<AudioSource>();
+                if (audioSource == null)
                 {
                     throw new Exception("AudioSource is not found");
                 }
@@ -34,7 +33,12 @@ namespace soundSystem_
 
         public void PlayBackgroundMusic(string name)
         {
-            audioSource.clip = soundSources.GetByName(name).Value.sound;
+            AudioClip clip = soundSources.GetClipByName(name);
+            if (clip == null)
+            {
+                return;
+            }
+            audioSource.clip = clip;
             audioSource.Play();
         }
 

--- a/Assets/Scripts/soundSystem]/SoundSources.cs
+++ b/Assets/Scripts/soundSystem]/SoundSources.cs
@@ -42,6 +42,21 @@ namespace soundSystem_
             return null;
         }
 
+        /// <summary>
+        /// Clip for a sound name, or null with a warning when it is missing.
+        /// Callers used to do GetByName(name).Value, which throws on an unknown name.
+        /// </summary>
+        public AudioClip GetClipByName(string name)
+        {
+            SoundSource? source = GetByName(name);
+            if (source == null)
+            {
+                Debug.LogWarning($"Sound '{name}' not found in SoundSources");
+                return null;
+            }
+            return source.Value.sound;
+        }
+
         public SoundSource? GetById(int id)
         {
             foreach (SoundSource source in soundSources)

--- a/Assets/Scripts/soundSystem]/ToggleableObjectSoundController.cs
+++ b/Assets/Scripts/soundSystem]/ToggleableObjectSoundController.cs
@@ -13,8 +13,8 @@ namespace soundSystem_
 
         public void SetType(string type)
         {
-            audioClips[0] = SoundManager.Instance.soundSources.GetByName(type + "Close").Value.sound;
-            audioClips[1] = SoundManager.Instance.soundSources.GetByName(type + "Open").Value.sound;
+            audioClips[0] = SoundManager.Instance.soundSources.GetClipByName(type + "Close");
+            audioClips[1] = SoundManager.Instance.soundSources.GetClipByName(type + "Open");
         }
 
         public void PlaySound(bool isOpen)

--- a/Assets/Scripts/soundSystem]/UISoundController.cs
+++ b/Assets/Scripts/soundSystem]/UISoundController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using InputSystem;
+using UnityEngine;
 
 namespace soundSystem_
 {
@@ -9,7 +10,7 @@ namespace soundSystem_
 
     public class UISoundController : SoundController, IKeyInputListener
     {
-        private readonly List<SoundSource> soundSources = new List<SoundSource>();
+        private readonly List<AudioClip> clips = new List<AudioClip>();
 
         protected override void Awake()
         {
@@ -24,13 +25,17 @@ namespace soundSystem_
 
         public void PlayButton(UISound uISound)
         {
-            audioSource.clip = soundSources[(int)uISound].sound;
+            if ((int)uISound >= clips.Count || clips[(int)uISound] == null)
+            {
+                return;
+            }
+            audioSource.clip = clips[(int)uISound];
             audioSource.Play();
         }
 
         private void InitSoundSources()
         {
-            soundSources.Add(SoundManager.Instance.soundSources.GetByName("ButtonSound").Value);
+            clips.Add(SoundManager.Instance.soundSources.GetClipByName("ButtonSound"));
         }
 
         void IKeyInputListener.OnKeyDown(ActionCode action)


### PR DESCRIPTION
Closes #206

## 요약

스크립트 81개를 전부 읽고 확인된 결함을 수정했습니다. 씬 전환으로 파괴된 리스너가 `InputManager`의 코루틴을 죽여 **입력이 영구 정지**되던 것이 여러 증상의 공통 원인이었습니다. 개별 호출부가 아니라 리스너를 순회하는 한 곳에서 막았습니다.

## 진행 불가 버그

| 파일 | 문제 | 수정 |
| --- | --- | --- |
| `InputSystem/InputManager.cs` | 파괴된 리스너 하나의 예외로 `CallListenersCoroutine`이 죽어 입력 전체가 영구 정지 | 파괴된 리스너 제거 + 예외 격리, 역방향 순회로 순회 중 등록 · 해제 허용 |
| `Portal/Portal.cs` | Portal 자신이 코루틴을 실행 → `LoadScene`이 Portal을 파괴해 위치 이동 · FadeIn 미실행 | `PortalManager`가 실행, Player 태그 검사, 중복 전환 차단 |
| `Slide_Puzzle/PuzzleInteract.cs` | `base.Start()` 미호출로 키 리스너 미등록 → 퍼즐을 열 수 없음 | `base.Start()` / `base.OnTriggerEnter2D()` 호출 |
| `Scripts_door/DoorObject.cs` | 빈 슬롯의 `itemSlot.item` 역참조 크래시 | null 검사 선행 |
| `Dialogue/NpcDialogueController.cs` | 대사 null일 때 `timeScale = 0` 상태로 예외 → 게임 영구 정지 | null · 중복 실행 가드 |
| `Portal/CameraEffector.cs` | 페이드가 `Time.deltaTime` 사용 → `timeScale = 0`에서 끝나지 않음 | `unscaledDeltaTime`, 미사용 이펙트 클래스 제거 |

## AI · 사운드

- `PathFinder`: `CompareTo`가 `Equals`와 불일치해 `SortedSet`이 비용이 같은 다른 타일을 동일 원소로 보고 버리던 문제(A* 경로 손실). 좌표 tiebreak 추가, 정렬 키인 비용을 바꾸기 전에 set에서 제거하도록 변경. 범위 밖 `GetNode` 인덱스 초과와 `Mathf.Sign(0) == 1`로 인한 방향 매칭 실패도 수정
- `Creature`: `AVOIDING`, `STUNNED` 값 중복 해소. 미등록 상태 · 예외가 `CreatureUpdate`를 죽여 크리처가 영구 정지하던 문제 차단
- `Guard`: `StopAllCoroutines()`가 `CreatureUpdate`까지 중단하고 `StartPatrol()`이 복구하지 않아 NPC 이벤트 후 정지하던 문제
- `SoundDetector`: AudioSource 없는 타겟 null 역참조
- `ActorSoundController`: `Mathf.Min(walkSounds.Count, walkSounds.Count)` 오타, 0일 때 `% 0`
- `SoundSources`: `GetByName(...).Value` 호출부 5곳을 `GetClipByName`으로 통일

## 아이템 · 스탯

- `HandLightSwitch`: 항상 참이던 `battery >= 0` → `> 0`, 배터리 사용 시 점등 순서 수정
- `CharacterStat`: 정신력 클램프 추가, 0 도달 시 코루틴이 종료되어 회복 후에도 감소가 재개되지 않던 문제를 무한 루프로 변경해 해결
- `Inventory`: 소비 아이템 소진 후 남은 버튼으로 인한 크래시
- `ItemObject`: 인벤토리가 가득 차도 오브젝트를 파괴해 아이템이 소실되던 문제
- `PuzzleSwitch2F`: 이름 기반 플레이어 판정 → 태그 비교

그 외 null 가드(`Drawer`, `Furniture`, `SpotLight`, `NpcEventController`), `eventObjects` 중복 키, `CreatureManager` 재활성화 시 tilemap · pathfinder 중복 누적, `PasswordSystem`의 비활성 캔버스 조회를 정리했습니다.

## 검증

- Roslyn(netstandard2.1)으로 `Assets` 전체 스크립트 타입 체크 통과. uGUI · TextMeshPro · URP는 스텁으로 대체했으며, Unity 플레이어 빌드가 아니라 타입 검사입니다.
- **에디터 플레이 테스트는 하지 않았습니다.** 씬 · 프리팹 설정에 걸린 문제는 이 방식으로 확인할 수 없습니다.

## 리뷰 시 확인 부탁

- 크리처가 `Creature.OnTriggerEnter2D`에서 `Destroy(플레이어)`를 호출하지만 사망 · 리스폰 시스템이 없어 이후 게임을 이어갈 수 없습니다. 설계 결정이 필요해 이번 PR에서는 건드리지 않았습니다.
- `PuzzleSwitch2F`와 `Portal`에 태그 검사를 추가했으므로, 해당 오브젝트들의 Player 태그 설정을 확인해 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
